### PR TITLE
Add tests for HARNESS_OPTIONS, add two more options

### DIFF
--- a/lib/Test/Harness.pm
+++ b/lib/Test/Harness.pm
@@ -238,6 +238,7 @@ sub _new_harness {
     $args->{stdout} = $sub_args->{out}
       if exists $sub_args->{out};
 
+    my $class = $ENV{HARNESS_SUBCLASS} || 'TAP::Harness';
     if ( defined( my $env_opt = $ENV{HARNESS_OPTIONS} ) ) {
         for my $opt ( split /:/, $env_opt ) {
             if ( $opt =~ /^j(\d*)$/ ) {
@@ -246,13 +247,22 @@ sub _new_harness {
             elsif ( $opt eq 'c' ) {
                 $args->{color} = 1;
             }
+            elsif ( $opt =~ m/^f(.*)$/ ) {
+                my $fmt = $1;
+                $fmt =~ s/-/::/g;
+                $args->{formatter_class} = $fmt;
+            }
+            elsif ( $opt =~ m/^a(.*)$/ ) {
+                my $archive = $1;
+                $class = "TAP::Harness::Archive";
+                $args->{archive} = $archive
+            }
             else {
                 die "Unknown HARNESS_OPTIONS item: $opt\n";
             }
         }
     }
 
-    my $class = $ENV{HARNESS_SUBCLASS} || 'TAP::Harness';
     return TAP::Harness->_construct( $class, $args );
 }
 
@@ -534,6 +544,16 @@ Run <n> (default 9) parallel jobs.
 =item C<< c >>
 
 Try to color output. See L<TAP::Formatter::Base/"new">.
+
+=item C<< a<file.tgz> >>
+
+Will use L<TAP::Harness::Archive> as the harness class, and save the TAP to
+C<file.tgz>
+
+=item C<< fPackage-With-Dashes >>
+
+Set the formatter_class of the harness being run. Since the C<HARNESS_OPTIONS>
+is seperated by C<:>, we use C<-> instead.
 
 =back
 

--- a/t/compat/env.opts.t
+++ b/t/compat/env.opts.t
@@ -1,0 +1,40 @@
+#!/usr/bin/perl -w
+
+use strict;
+use Test::More (
+    $^O eq 'VMS'
+    ? ( skip_all => 'VMS' )
+    : ( tests => 12 )
+);
+
+use Test::Harness;
+{
+    # Should add a fake home dir? to test the rc stuff..
+    local $ENV{HARNESS_OPTIONS} = 'j4:c';
+
+    ok my $harness = Test::Harness::_new_harness, 'made harness';
+    is($harness->color, 1, "set color correctly");
+    is($harness->jobs, 4, "set jobs correctly");
+}
+{
+    local $ENV{HARNESS_OPTIONS} = 'j4:c:fTAP-Formatter-SocketConsole';
+
+    ok my $harness = Test::Harness::_new_harness, 'made harness';
+    is($harness->color, 1, "set color correctly");
+    is($harness->jobs, 4, "set jobs correctly");
+    is($harness->formatter_class, "TAP::Formatter::SocketConsole", "correct formatter");
+
+}
+{
+    # Test archive
+    local $ENV{HARNESS_OPTIONS} = 'j4:c:a/archive.tgz';
+
+    ok my $harness = Test::Harness::_new_harness, 'made harness';
+    is($harness->color, 1, "set color correctly");
+    is($harness->jobs, 4, "set jobs correctly");
+    isa_ok($harness, "TAP::Harness::Archive", "correct harness subclass");
+    # XXX: this is nasty :(
+    is($harness->{__archive_file}, "/archive.tgz", "correct archive found");
+
+}
+


### PR DESCRIPTION
Added the two options a(archive) and f(formatter) to HARNESS_OPTIONS, making it possible to specify an archive to use TAP::Harness::Archive, and an option of specifying the formatter_class.

Any questions, feedback or shoot downs appreciated :)
