### PR TITLE
Write out results in case of bail out.

### DIFF
--- a/lib/TAP/Harness.pm
+++ b/lib/TAP/Harness.pm
@@ -485,6 +485,10 @@ sub runtests {
         $self->aggregate_tests( $aggregate, @tests );
         $finish->();
     };
+    $self->{bail_summary} = sub{
+        print "\n";
+        $finish->(1);
+    };
 
     if ( $self->trap ) {
         local $SIG{INT} = sub {
@@ -524,6 +528,7 @@ sub _after_test {
 sub _bailout {
     my ( $self, $result ) = @_;
     my $explanation = $result->explanation;
+    $self->{bail_summary}();
     die "FAILED--Further testing stopped"
       . ( $explanation ? ": $explanation\n" : ".\n" );
 }


### PR DESCRIPTION
Give output formatters a chance to dump current results in the case of a bail out.

This probably isn't ready yet for inclusion.  I just wanted to get an opinion and may direction on how to modify this to get something that's acceptable.  It was suggested to me that I fork on github.  Sorry if that's wrong.

This is specifically to make it so TAP::Formatter::HTML will write out a log in the case that a test case aborts.  I don't know if there is a better fix, but it's small and seems to work without breaking normal output when run without a non-default formatter.  

I have it seen it report both that all tests passed and that the test run was interrupted.  So that probably at least one case that should be improved, but I consider it better than not reporting anything at all.
