### PR TITLE
Document HARNESS_PERL_SWITCHES

### DIFF
--- a/lib/Test/Harness.pm
+++ b/lib/Test/Harness.pm
@@ -519,6 +519,17 @@ This is the version of C<Test::Harness>.
 
 =over 4
 
+=item C<HARNESS_PERL_SWITCHES>
+
+Setting this adds perl command line switches to each test file run.
+
+For example, C<HARNESS_PERL_SWITCHES=-T> will turn on taint mode.
+C<HARNESS_PERL_SWITCHES=-MDevel::Cover> will run C<Devel::Cover> for
+each test.
+
+C<-w> is always set.  You can turn this off in the test with C<BEGIN {
+$^W = 0 }>.
+
 =item C<HARNESS_TIMER>
 
 Setting this to true will make the harness display the number of


### PR DESCRIPTION
I noticed it wasn't documented, but its mentioned all over various Perl documentation.  In particular its how you make [Devel::Cover](https://metacpan.org/module/Devel::Cover) work with prove or `make test`.

It would be nice if there was a prove switch to control Perl switches.
