### PR TITLE
PERL5LIB and taint

### DIFF
--- a/lib/TAP/Parser/SourceHandler/Perl.pm
+++ b/lib/TAP/Parser/SourceHandler/Perl.pm
@@ -152,17 +152,26 @@ sub make_iterator {
     $class->_run( $source, $libs, $switches );
 }
 
+
+sub _has_taint_switch {
+    my( $class, $switches ) = @_;
+
+    my $has_taint = grep { $_ eq "-T" || $_ eq "-t" } @{$switches};
+    return $has_taint ? 1 : 0;
+}
+
 sub _mangle_switches {
     my ( $class, $libs, $switches ) = @_;
 
     # Taint mode ignores environment variables so we must retranslate
     # PERL5LIB as -I switches and place PERL5OPT on the command line
     # in order that it be seen.
-    if ( grep { $_ eq "-T" || $_ eq "-t" } @{$switches} ) {
+    if ( $class->_has_taint_switch($switches) ) {
+        my @perl5lib = split /:/, $ENV{PERL5LIB};
         return (
             $libs,
             [   @{$switches},
-                $class->_libs2switches($libs),
+                $class->_libs2switches([@$libs, @perl5lib]),
                 split_shell( $ENV{PERL5OPT} )
             ],
         );
@@ -200,10 +209,10 @@ sub _filter_libs {
 }
 
 sub _iterator_hooks {
-    my ( $class, $source, $libs ) = @_;
+    my ( $class, $source, $libs, $switches ) = @_;
 
     my $setup = sub {
-        if ( @{$libs} ) {
+        if ( @{$libs} and !$class->_has_taint_switch($switches) ) {
             $ENV{PERL5LIB} = join(
                 $Config{path_sep}, grep {defined} @{$libs},
                 $ENV{PERL5LIB}
@@ -232,7 +241,7 @@ sub _run {
     my @command = $class->_get_command_for_switches( $source, $switches )
       or $class->_croak("No command found!");
 
-    my ( $setup, $teardown ) = $class->_iterator_hooks( $source, $libs );
+    my ( $setup, $teardown ) = $class->_iterator_hooks( $source, $libs, $switches );
 
     return $class->_create_iterator( $source, \@command, $setup, $teardown );
 }

--- a/t/compat/inc-propagation.t
+++ b/t/compat/inc-propagation.t
@@ -36,10 +36,9 @@ use lib 'wibble';
 my $test_template = <<'END';
 #!/usr/bin/perl %s
 
-use Test::More tests => 2;
+use Test::More tests => 1;
 
 is $INC[0], "wibble", 'basic order of @INC preserved' or diag "\@INC: @INC";
-like $ENV{PERL5LIB}, qr{wibble};
 
 END
 

--- a/t/taint.t
+++ b/t/taint.t
@@ -4,10 +4,10 @@ BEGIN {
     unshift @INC, 't/lib';
 }
 
-# Test that options in PERL5OPT are propogated to tainted tests
+# Test that environment options are propagated to tainted tests
 
 use strict;
-use Test::More ( $^O eq 'VMS' ? ( skip_all => 'VMS' ) : ( tests => 1 ) );
+use Test::More ( $^O eq 'VMS' ? ( skip_all => 'VMS' ) : ( tests => 2 ) );
 
 use Config;
 use TAP::Parser;
@@ -44,6 +44,20 @@ sub run_test_file {
 
 print "1..1\n";
 print $INC{'strict.pm'} ? "ok 1\n" : "not ok 1\n";
+END
+}
+
+
+# Check that PERL5LIB is propagated to -T.
+{
+    my $sentinel_dir = 'i/do/not/exist';
+    local $ENV{PERL5LIB} = join $Config{path_sep}, $ENV{PERL5LIB}, $sentinel_dir;
+    run_test_file(sprintf <<'END', $sentinel_dir);
+#!/usr/bin/perl -T
+
+print "1..1\n";
+my $ok = grep { $_ eq '%s' } @INC;
+print $ok ? "ok 1\n" : "not ok 1\n";
 END
 }
 


### PR DESCRIPTION
This is a fix for [rt.cpan.org 84377](https://rt.cpan.org/Ticket/Display.html?id=84377).  It ensures PERL5LIB is always propagated into a tests' `@INC` even if the test has taint mode on.  This makes running tests much more consistent and makes it possible to run taint mode tests in a local::lib or Perl home dir library environment.

Test::Harness already has code to ensure this.  TAP::Harness (and thus prove) did not.  It's possible the Test::Harness code is now redundant.
