### PR TITLE
Please pull the customisable colours patch.

### DIFF
--- a/lib/TAP/Formatter/Console.pm
+++ b/lib/TAP/Formatter/Console.pm
@@ -73,13 +73,13 @@ sub _set_colors {
 sub _failure_color {
     my ($self) = @_;
 
-    return $ENV{'HARNESS_SUMMARY_COL_FAIL'} || 'red';
+    return $ENV{'HARNESS_SUMMARY_COLOR_FAIL'} || 'red';
 }
 
 sub _success_color {
     my ($self) = @_;
 
-    return $ENV{'HARNESS_SUMMARY_COL_SUC'} || 'green';
+    return $ENV{'HARNESS_SUMMARY_COLOR_SUCCESS'} || 'green';
 }
 
 sub _output_success {

--- a/lib/Test/Harness.pm
+++ b/lib/Test/Harness.pm
@@ -576,12 +576,12 @@ Multiple options may be separated by colons:
 
 Specifies a TAP::Harness subclass to be used in place of TAP::Harness.
 
-=item C<HARNESS_SUMMARY_COL_SUC>
+=item C<HARNESS_SUMMARY_COLOR_SUCCESS>
 
 Determines the L<Term::ANSIColor> for the summary in case it is successful.
 This color defaults to C<'green'>.
 
-=item C<HARNESS_SUMMARY_COL_FAIL>
+=item C<HARNESS_SUMMARY_COLOR_FAIL>
 
 Determines the L<Term::ANSIColor> for the failure in case it is successful.
 This color defaults to C<'red'>.

--- a/t/harness.t
+++ b/t/harness.t
@@ -14,8 +14,8 @@ use TAP::Harness;
 # This is done to prevent the colors environment variables from
 # interfering.
 local %ENV = %ENV;
-delete $ENV{HARNESS_SUMMARY_COL_FAIL};
-delete $ENV{HARNESS_SUMMARY_COL_SUC};
+delete $ENV{HARNESS_SUMMARY_COLOR_FAIL};
+delete $ENV{HARNESS_SUMMARY_COLOR_SUCCESS};
 
 my $HARNESS = 'TAP::Harness';
 


### PR DESCRIPTION
Hi all I added customisable colours to TAP::Harness, because I hate the current hard-coded choice. Please pull.

This was supposedly merged here, but I don't see it anywhere in the history:

https://github.com/AndyA/Test-Harness/pull/3

Regards,

-- Shlomi Fish
