### PR TITLE
document the changes to -w behavior in changelog

### DIFF
--- a/Changes
+++ b/Changes
@@ -9,6 +9,7 @@ Revision history for Test-Harness
           Reduces memory usage (Nick Clark, RT #84939)
         - PERL5LIB is always propogated to a test's @INC, even with taint more
           (Schwern, RT #84377)
+        - restore "always add -w to switches" behavior
 
 3.26    2013-01-16
         - Renamed env.opts.t to env_opts.t (for VMS)
@@ -28,6 +29,7 @@ Revision history for Test-Harness
           test more gracefully.
         - Make the test summary 'ok' line overrideable so that it can be
           changed to a plugin to make the output of prove idempotent.
+        - Stop adding '-w' to perl switches by default
         - Apply upstream patch:
 
             http://perl5.git.perl.org/perl.git/commit \
@@ -41,6 +43,7 @@ Revision history for Test-Harness
           running it feels like a bad idea, given that the file's name is as predictable
           as process IDs, as there's a race condition to break into the account running
           perl's tests.
+
 
 3.23    2011-02-20
         - Merge in changes from core. Thanks BinGOs.


### PR DESCRIPTION
The behavior of adding -w to switches changed twice in the last year or so.  These changes are not in the changelog.  They should be.
