### PR TITLE
Respect PERL5LIB in tainting source handler test

### DIFF
--- a/t/source_handler.t
+++ b/t/source_handler.t
@@ -87,6 +87,7 @@ my %file = map { $_ => File::Spec->catfile( $dir, $_ ) }
             {   name => "valid executable",
                 raw  => [
                     $perl, ( $ENV{PERL_CORE} ? '-I../../lib' : () ),
+                    (map { "-I$_" } split /:/, $ENV{PERL5LIB} || ''),
                     '-It/lib', '-T', $file{source}
                 ],
                 iclass        => 'TAP::Parser::Iterator::Process',


### PR DESCRIPTION
Otherwise it breaks on Perl 5.8 if parent.pm is installed somewhere in
PERL5LIB rather than the default dirs (e.g. when using local::lib or
'perlbrew lib').
