### PR TITLE
Link to TAP::Formatter::Color in documentation

### DIFF
--- a/bin/prove
+++ b/bin/prove
@@ -107,9 +107,9 @@ matching the pattern C<t/*.t>.
 
 =head2 Colored Test Output
 
-Colored test output is the default, but if output is not to a
-terminal, color is disabled. You can override this by adding the
-C<--color> switch.
+Colored test output using L<TAP::Formatter::Color> is the default, but 
+if output is not to a terminal, color is disabled. You can override this by 
+adding the C<--color> switch.
 
 Color support requires L<Term::ANSIColor> on Unix-like platforms and
 L<Win32::Console> windows. If the necessary module is not installed


### PR DESCRIPTION
Colored output wasn't working for me, so the first thing I looked for was documentation about what colors I should be seeing. This turned out to be in TAP::Formatter::Color, so I think it would be useful to link to it in the documentation. It also may be important for people to see that the formatter is labeled as experimental (though it's been around a while).
