### PR TITLE
use base instead of parent

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -20,7 +20,6 @@ my %mm_args = (
    # The core autogenerates a Makefile.PL, and finds prove with utils/prove.PL
     'EXE_FILES' => ['bin/prove'],
     'PREREQ_PM'    => {
-        parent => 0,
     }
 );
 

--- a/inc/MyBuilder.pm
+++ b/inc/MyBuilder.pm
@@ -3,7 +3,7 @@ package MyBuilder;
 use strict;
 use warnings;
 
-use parent qw(Module::Build);
+use base qw(Module::Build);
 
 # Test with Test::Harness
 sub ACTION_test_with_harness {

--- a/lib/App/Prove.pm
+++ b/lib/App/Prove.pm
@@ -10,7 +10,7 @@ use Getopt::Long;
 use App::Prove::State;
 use Carp;
 
-use parent 'TAP::Object';
+use base 'TAP::Object';
 
 =head1 NAME
 

--- a/lib/App/Prove/State.pm
+++ b/lib/App/Prove/State.pm
@@ -10,7 +10,7 @@ use Carp;
 use App::Prove::State::Result;
 use TAP::Parser::YAMLish::Reader ();
 use TAP::Parser::YAMLish::Writer ();
-use parent 'TAP::Base';
+use base 'TAP::Base';
 
 BEGIN {
     __PACKAGE__->mk_methods('result_class');

--- a/lib/TAP/Base.pm
+++ b/lib/TAP/Base.pm
@@ -3,7 +3,7 @@ package TAP::Base;
 use strict;
 use warnings;
 
-use parent 'TAP::Object';
+use base 'TAP::Object';
 
 =head1 NAME
 
@@ -27,7 +27,7 @@ use constant GOT_TIME_HIRES => do {
 
     package TAP::Whatever;
 
-    use parent 'TAP::Base';
+    use base 'TAP::Base';
 
     # ... later ...
     

--- a/lib/TAP/Formatter/Base.pm
+++ b/lib/TAP/Formatter/Base.pm
@@ -2,7 +2,7 @@ package TAP::Formatter::Base;
 
 use strict;
 use warnings;
-use parent 'TAP::Base';
+use base 'TAP::Base';
 use POSIX qw(strftime);
 
 my $MAX_ERRORS = 5;

--- a/lib/TAP/Formatter/Color.pm
+++ b/lib/TAP/Formatter/Color.pm
@@ -5,7 +5,7 @@ use warnings;
 
 use constant IS_WIN32 => ( $^O =~ /^(MS)?Win32$/ );
 
-use parent 'TAP::Object';
+use base 'TAP::Object';
 
 my $NO_COLOR;
 

--- a/lib/TAP/Formatter/Console.pm
+++ b/lib/TAP/Formatter/Console.pm
@@ -2,7 +2,7 @@ package TAP::Formatter::Console;
 
 use strict;
 use warnings;
-use parent 'TAP::Formatter::Base';
+use base 'TAP::Formatter::Base';
 use POSIX qw(strftime);
 
 =head1 NAME

--- a/lib/TAP/Formatter/Console/ParallelSession.pm
+++ b/lib/TAP/Formatter/Console/ParallelSession.pm
@@ -6,7 +6,7 @@ use File::Spec;
 use File::Path;
 use Carp;
 
-use parent 'TAP::Formatter::Console::Session';
+use base 'TAP::Formatter::Console::Session';
 
 use constant WIDTH => 72;    # Because Eric says
 

--- a/lib/TAP/Formatter/Console/Session.pm
+++ b/lib/TAP/Formatter/Console/Session.pm
@@ -3,7 +3,7 @@ package TAP::Formatter::Console::Session;
 use strict;
 use warnings;
 
-use parent 'TAP::Formatter::Session';
+use base 'TAP::Formatter::Session';
 
 my @ACCESSOR;
 

--- a/lib/TAP/Formatter/File.pm
+++ b/lib/TAP/Formatter/File.pm
@@ -5,7 +5,7 @@ use warnings;
 use TAP::Formatter::File::Session;
 use POSIX qw(strftime);
 
-use parent 'TAP::Formatter::Base';
+use base 'TAP::Formatter::Base';
 
 =head1 NAME
 

--- a/lib/TAP/Formatter/File/Session.pm
+++ b/lib/TAP/Formatter/File/Session.pm
@@ -2,7 +2,7 @@ package TAP::Formatter::File::Session;
 
 use strict;
 use warnings;
-use parent 'TAP::Formatter::Session';
+use base 'TAP::Formatter::Session';
 
 =head1 NAME
 

--- a/lib/TAP/Formatter/Session.pm
+++ b/lib/TAP/Formatter/Session.pm
@@ -3,7 +3,7 @@ package TAP::Formatter::Session;
 use strict;
 use warnings;
 
-use parent 'TAP::Base';
+use base 'TAP::Base';
 
 my @ACCESSOR;
 

--- a/lib/TAP/Harness.pm
+++ b/lib/TAP/Harness.pm
@@ -8,7 +8,7 @@ use File::Spec;
 use File::Path;
 use IO::Handle;
 
-use parent 'TAP::Base';
+use base 'TAP::Base';
 
 =head1 NAME
 

--- a/lib/TAP/Harness/Beyond.pod
+++ b/lib/TAP/Harness/Beyond.pod
@@ -227,7 +227,7 @@ document:
 
   package My::TAP::Harness;
 
-  use parent 'TAP::Harness';
+  use base 'TAP::Harness';
   use YAML;
 
   sub summary {

--- a/lib/TAP/Object.pm
+++ b/lib/TAP/Object.pm
@@ -21,7 +21,7 @@ our $VERSION = '3.29';
 
     use strict;
 
-    use parent 'TAP::Object';
+    use base 'TAP::Object';
 
     # new() implementation by TAP::Object
     sub _initialize {

--- a/lib/TAP/Parser.pm
+++ b/lib/TAP/Parser.pm
@@ -17,7 +17,7 @@ use TAP::Parser::SourceHandler::Handle     ();
 
 use Carp qw( confess );
 
-use parent 'TAP::Base';
+use base 'TAP::Base';
 
 =encoding utf8
 

--- a/lib/TAP/Parser/Aggregator.pm
+++ b/lib/TAP/Parser/Aggregator.pm
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 use Benchmark;
 
-use parent 'TAP::Object';
+use base 'TAP::Object';
 
 =head1 NAME
 

--- a/lib/TAP/Parser/Grammar.pm
+++ b/lib/TAP/Parser/Grammar.pm
@@ -6,7 +6,7 @@ use warnings;
 use TAP::Parser::ResultFactory   ();
 use TAP::Parser::YAMLish::Reader ();
 
-use parent 'TAP::Object';
+use base 'TAP::Object';
 
 =head1 NAME
 

--- a/lib/TAP/Parser/Iterator.pm
+++ b/lib/TAP/Parser/Iterator.pm
@@ -3,7 +3,7 @@ package TAP::Parser::Iterator;
 use strict;
 use warnings;
 
-use parent 'TAP::Object';
+use base 'TAP::Object';
 
 =head1 NAME
 
@@ -21,7 +21,7 @@ our $VERSION = '3.29';
 
   # to subclass:
   use TAP::Parser::Iterator ();
-  use parent 'TAP::Parser::Iterator';
+  use base 'TAP::Parser::Iterator';
   sub _initialize {
     # see TAP::Object...
   }

--- a/lib/TAP/Parser/Iterator/Array.pm
+++ b/lib/TAP/Parser/Iterator/Array.pm
@@ -3,7 +3,7 @@ package TAP::Parser::Iterator::Array;
 use strict;
 use warnings;
 
-use parent 'TAP::Parser::Iterator';
+use base 'TAP::Parser::Iterator';
 
 =head1 NAME
 

--- a/lib/TAP/Parser/Iterator/Process.pm
+++ b/lib/TAP/Parser/Iterator/Process.pm
@@ -6,7 +6,7 @@ use warnings;
 use Config;
 use IO::Handle;
 
-use parent 'TAP::Parser::Iterator';
+use base 'TAP::Parser::Iterator';
 
 my $IS_WIN32 = ( $^O =~ /^(MS)?Win32$/ );
 

--- a/lib/TAP/Parser/Iterator/Stream.pm
+++ b/lib/TAP/Parser/Iterator/Stream.pm
@@ -3,7 +3,7 @@ package TAP::Parser::Iterator::Stream;
 use strict;
 use warnings;
 
-use parent 'TAP::Parser::Iterator';
+use base 'TAP::Parser::Iterator';
 
 =head1 NAME
 

--- a/lib/TAP/Parser/IteratorFactory.pm
+++ b/lib/TAP/Parser/IteratorFactory.pm
@@ -6,7 +6,7 @@ use warnings;
 use Carp qw( confess );
 use File::Basename qw( fileparse );
 
-use parent 'TAP::Object';
+use base 'TAP::Object';
 
 use constant handlers => [];
 
@@ -301,7 +301,7 @@ But in case you find the need to...
 
   use strict;
 
-  use parent 'TAP::Parser::IteratorFactory';
+  use base 'TAP::Parser::IteratorFactory';
 
   # override source detection algorithm
   sub detect_source {

--- a/lib/TAP/Parser/Multiplexer.pm
+++ b/lib/TAP/Parser/Multiplexer.pm
@@ -5,7 +5,7 @@ use warnings;
 
 use IO::Select;
 
-use parent 'TAP::Object';
+use base 'TAP::Object';
 
 use constant IS_WIN32 => $^O =~ /^(MS)?Win32$/;
 use constant IS_VMS => $^O eq 'VMS';

--- a/lib/TAP/Parser/Result.pm
+++ b/lib/TAP/Parser/Result.pm
@@ -3,7 +3,7 @@ package TAP::Parser::Result;
 use strict;
 use warnings;
 
-use parent 'TAP::Object';
+use base 'TAP::Object';
 
 BEGIN {
 
@@ -273,7 +273,7 @@ subclass L<TAP::Parser::Grammar> too, or else it'll never get used.
 
   use strict;
 
-  use parent 'TAP::Parser::Result';
+  use base 'TAP::Parser::Result';
 
   # register with the factory:
   TAP::Parser::ResultFactory->register_type( 'my_type' => __PACKAGE__ );

--- a/lib/TAP/Parser/Result/Bailout.pm
+++ b/lib/TAP/Parser/Result/Bailout.pm
@@ -3,7 +3,7 @@ package TAP::Parser::Result::Bailout;
 use strict;
 use warnings;
 
-use parent 'TAP::Parser::Result';
+use base 'TAP::Parser::Result';
 
 =head1 NAME
 

--- a/lib/TAP/Parser/Result/Comment.pm
+++ b/lib/TAP/Parser/Result/Comment.pm
@@ -3,7 +3,7 @@ package TAP::Parser::Result::Comment;
 use strict;
 use warnings;
 
-use parent 'TAP::Parser::Result';
+use base 'TAP::Parser::Result';
 
 =head1 NAME
 

--- a/lib/TAP/Parser/Result/Plan.pm
+++ b/lib/TAP/Parser/Result/Plan.pm
@@ -3,7 +3,7 @@ package TAP::Parser::Result::Plan;
 use strict;
 use warnings;
 
-use parent 'TAP::Parser::Result';
+use base 'TAP::Parser::Result';
 
 =head1 NAME
 

--- a/lib/TAP/Parser/Result/Pragma.pm
+++ b/lib/TAP/Parser/Result/Pragma.pm
@@ -3,7 +3,7 @@ package TAP::Parser::Result::Pragma;
 use strict;
 use warnings;
 
-use parent 'TAP::Parser::Result';
+use base 'TAP::Parser::Result';
 
 =head1 NAME
 

--- a/lib/TAP/Parser/Result/Test.pm
+++ b/lib/TAP/Parser/Result/Test.pm
@@ -3,7 +3,7 @@ package TAP::Parser::Result::Test;
 use strict;
 use warnings;
 
-use parent 'TAP::Parser::Result';
+use base 'TAP::Parser::Result';
 
 =head1 NAME
 

--- a/lib/TAP/Parser/Result/Unknown.pm
+++ b/lib/TAP/Parser/Result/Unknown.pm
@@ -3,7 +3,7 @@ package TAP::Parser::Result::Unknown;
 use strict;
 use warnings;
 
-use parent 'TAP::Parser::Result';
+use base 'TAP::Parser::Result';
 
 =head1 NAME
 

--- a/lib/TAP/Parser/Result/Version.pm
+++ b/lib/TAP/Parser/Result/Version.pm
@@ -3,7 +3,7 @@ package TAP::Parser::Result::Version;
 use strict;
 use warnings;
 
-use parent 'TAP::Parser::Result';
+use base 'TAP::Parser::Result';
 
 =head1 NAME
 

--- a/lib/TAP/Parser/Result/YAML.pm
+++ b/lib/TAP/Parser/Result/YAML.pm
@@ -3,7 +3,7 @@ package TAP::Parser::Result::YAML;
 use strict;
 use warnings;
 
-use parent 'TAP::Parser::Result';
+use base 'TAP::Parser::Result';
 
 =head1 NAME
 

--- a/lib/TAP/Parser/ResultFactory.pm
+++ b/lib/TAP/Parser/ResultFactory.pm
@@ -12,7 +12,7 @@ use TAP::Parser::Result::Unknown ();
 use TAP::Parser::Result::Version ();
 use TAP::Parser::Result::YAML    ();
 
-use parent 'TAP::Object';
+use base 'TAP::Object';
 
 ##############################################################################
 
@@ -82,7 +82,7 @@ a completely new type, eg:
   # create a custom result type:
   package MyResult;
   use strict;
-  use parent 'TAP::Parser::Result';
+  use base 'TAP::Parser::Result';
 
   # register with the factory:
   TAP::Parser::ResultFactory->register_type( 'my_type' => __PACKAGE__ );
@@ -165,7 +165,7 @@ Of course, it's up to you to decide whether or not to ignore them.
 
   use MyResult;
 
-  use parent 'TAP::Parser::ResultFactory';
+  use base 'TAP::Parser::ResultFactory';
 
   # force all results to be 'MyResult'
   sub class_for {

--- a/lib/TAP/Parser/Source.pm
+++ b/lib/TAP/Parser/Source.pm
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 
 use File::Basename qw( fileparse );
-use parent 'TAP::Object';
+use base 'TAP::Object';
 
 use constant BLK_SIZE => 512;
 

--- a/lib/TAP/Parser/SourceHandler.pm
+++ b/lib/TAP/Parser/SourceHandler.pm
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 
 use TAP::Parser::Iterator ();
-use parent 'TAP::Object';
+use base 'TAP::Object';
 
 =head1 NAME
 
@@ -25,7 +25,7 @@ our $VERSION = '3.29';
 
   # must be sub-classed for use
   package MySourceHandler;
-  use parent 'TAP::Parser::SourceHandler';
+  use base 'TAP::Parser::SourceHandler';
   sub can_handle    { return $confidence_level }
   sub make_iterator { return $iterator }
 
@@ -125,7 +125,7 @@ L<TAP::Parser::IteratorFactory/register_handler>.
   use MySourceHandler; # see TAP::Parser::SourceHandler
   use TAP::Parser::IteratorFactory;
 
-  use parent 'TAP::Parser::SourceHandler';
+  use base 'TAP::Parser::SourceHandler';
 
   TAP::Parser::IteratorFactory->register_handler( __PACKAGE__ );
 

--- a/lib/TAP/Parser/SourceHandler/Executable.pm
+++ b/lib/TAP/Parser/SourceHandler/Executable.pm
@@ -6,7 +6,7 @@ use warnings;
 use TAP::Parser::IteratorFactory   ();
 use TAP::Parser::Iterator::Process ();
 
-use parent 'TAP::Parser::SourceHandler';
+use base 'TAP::Parser::SourceHandler';
 
 TAP::Parser::IteratorFactory->register_handler(__PACKAGE__);
 
@@ -159,7 +159,7 @@ Please see L<TAP::Parser/SUBCLASSING> for a subclassing overview.
   use Carp qw( croak );
   use TAP::Parser::SourceHandler::Executable;
 
-  use parent 'TAP::Parser::SourceHandler::Executable';
+  use base 'TAP::Parser::SourceHandler::Executable';
 
   # expect $handler->(['mytest.rb', 'cmdline', 'args']);
   sub make_iterator {

--- a/lib/TAP/Parser/SourceHandler/File.pm
+++ b/lib/TAP/Parser/SourceHandler/File.pm
@@ -6,7 +6,7 @@ use warnings;
 use TAP::Parser::IteratorFactory  ();
 use TAP::Parser::Iterator::Stream ();
 
-use parent 'TAP::Parser::SourceHandler';
+use base 'TAP::Parser::SourceHandler';
 
 TAP::Parser::IteratorFactory->register_handler(__PACKAGE__);
 

--- a/lib/TAP/Parser/SourceHandler/Handle.pm
+++ b/lib/TAP/Parser/SourceHandler/Handle.pm
@@ -6,7 +6,7 @@ use warnings;
 use TAP::Parser::IteratorFactory  ();
 use TAP::Parser::Iterator::Stream ();
 
-use parent 'TAP::Parser::SourceHandler';
+use base 'TAP::Parser::SourceHandler';
 
 TAP::Parser::IteratorFactory->register_handler(__PACKAGE__);
 

--- a/lib/TAP/Parser/SourceHandler/Perl.pm
+++ b/lib/TAP/Parser/SourceHandler/Perl.pm
@@ -11,7 +11,7 @@ use TAP::Parser::IteratorFactory           ();
 use TAP::Parser::Iterator::Process         ();
 use Text::ParseWords qw(shellwords);
 
-use parent 'TAP::Parser::SourceHandler::Executable';
+use base 'TAP::Parser::SourceHandler::Executable';
 
 TAP::Parser::IteratorFactory->register_handler(__PACKAGE__);
 
@@ -344,7 +344,7 @@ Please see L<TAP::Parser/SUBCLASSING> for a subclassing overview.
 
   use TAP::Parser::SourceHandler::Perl;
 
-  use parent 'TAP::Parser::SourceHandler::Perl';
+  use base 'TAP::Parser::SourceHandler::Perl';
 
   # use the version of perl from the shebang line in the test file
   sub get_perl {

--- a/lib/TAP/Parser/SourceHandler/RawTAP.pm
+++ b/lib/TAP/Parser/SourceHandler/RawTAP.pm
@@ -6,7 +6,7 @@ use warnings;
 use TAP::Parser::IteratorFactory ();
 use TAP::Parser::Iterator::Array ();
 
-use parent 'TAP::Parser::SourceHandler';
+use base 'TAP::Parser::SourceHandler';
 
 TAP::Parser::IteratorFactory->register_handler(__PACKAGE__);
 

--- a/lib/TAP/Parser/YAMLish/Reader.pm
+++ b/lib/TAP/Parser/YAMLish/Reader.pm
@@ -3,7 +3,7 @@ package TAP::Parser::YAMLish::Reader;
 use strict;
 use warnings;
 
-use parent 'TAP::Object';
+use base 'TAP::Object';
 
 our $VERSION = '3.29';
 

--- a/lib/TAP/Parser/YAMLish/Writer.pm
+++ b/lib/TAP/Parser/YAMLish/Writer.pm
@@ -3,7 +3,7 @@ package TAP::Parser::YAMLish::Writer;
 use strict;
 use warnings;
 
-use parent 'TAP::Object';
+use base 'TAP::Object';
 
 our $VERSION = '3.29';
 

--- a/lib/Test/Harness.pm
+++ b/lib/Test/Harness.pm
@@ -16,7 +16,7 @@ use TAP::Parser::SourceHandler::Perl ();
 use Text::ParseWords qw(shellwords);
 
 use Config;
-use parent 'Exporter';
+use base 'Exporter';
 
 # $ML $Last_ML_Print
 

--- a/t/base.t
+++ b/t/base.t
@@ -54,7 +54,7 @@ use TAP::Base;
 package CallbackOK;
 
 use TAP::Base;
-use parent 'TAP::Base';
+use base 'TAP::Base';
 
 sub _initialize {
     my $self = shift;

--- a/t/iterators.t
+++ b/t/iterators.t
@@ -29,7 +29,7 @@ my $setup    = sub { $did_setup++ };
 my $teardown = sub { $did_teardown++ };
 
 package NoForkProcess;
-use parent qw( TAP::Parser::Iterator::Process );
+use base qw( TAP::Parser::Iterator::Process );
 
 sub _use_open3 {return}
 

--- a/t/lib/EmptyParser.pm
+++ b/t/lib/EmptyParser.pm
@@ -3,7 +3,7 @@ package EmptyParser;
 use strict;
 use warnings;
 
-use parent qw(TAP::Parser);
+use base qw(TAP::Parser);
 
 sub _initialize {
     shift->_set_defaults;

--- a/t/lib/MyFileSourceHandler.pm
+++ b/t/lib/MyFileSourceHandler.pm
@@ -8,7 +8,7 @@ our ($LAST_OBJ, $CAN_HANDLE, $MAKE_ITER, $LAST_SOURCE);
 
 use TAP::Parser::IteratorFactory;
 
-use parent qw( TAP::Parser::SourceHandler::File MyCustom );
+use base qw( TAP::Parser::SourceHandler::File MyCustom );
 $LAST_OBJ    = undef;
 $CAN_HANDLE  = undef;
 $MAKE_ITER   = undef;

--- a/t/lib/MyGrammar.pm
+++ b/t/lib/MyGrammar.pm
@@ -5,7 +5,7 @@ package MyGrammar;
 use strict;
 use warnings;
 
-use parent qw( TAP::Parser::Grammar MyCustom );
+use base qw( TAP::Parser::Grammar MyCustom );
 
 sub _initialize {
     my $self = shift;

--- a/t/lib/MyIterator.pm
+++ b/t/lib/MyIterator.pm
@@ -5,7 +5,7 @@ package MyIterator;
 use strict;
 use warnings;
 
-use parent qw( TAP::Parser::Iterator MyCustom );
+use base qw( TAP::Parser::Iterator MyCustom );
 
 sub _initialize {
     my $self = shift;

--- a/t/lib/MyPerlSourceHandler.pm
+++ b/t/lib/MyPerlSourceHandler.pm
@@ -7,7 +7,7 @@ use warnings;
 
 use TAP::Parser::IteratorFactory;
 
-use parent qw( TAP::Parser::SourceHandler::Perl MyCustom );
+use base qw( TAP::Parser::SourceHandler::Perl MyCustom );
 
 TAP::Parser::IteratorFactory->register_handler(__PACKAGE__);
 

--- a/t/lib/MyResult.pm
+++ b/t/lib/MyResult.pm
@@ -5,7 +5,7 @@ package MyResult;
 use strict;
 use warnings;
 
-use parent qw( TAP::Parser::Result MyCustom );
+use base qw( TAP::Parser::Result MyCustom );
 
 sub _initialize {
     my $self = shift;

--- a/t/lib/MyResultFactory.pm
+++ b/t/lib/MyResultFactory.pm
@@ -7,7 +7,7 @@ use warnings;
 
 use MyResult;
 
-use parent qw( TAP::Parser::ResultFactory MyCustom );
+use base qw( TAP::Parser::ResultFactory MyCustom );
 
 sub make_result {
     my $class = shift;

--- a/t/lib/MySourceHandler.pm
+++ b/t/lib/MySourceHandler.pm
@@ -9,8 +9,8 @@ use MyIterator;
 use TAP::Parser::SourceHandler;
 use TAP::Parser::IteratorFactory;
 
-#use parent qw( TAP::Parser::SourceHandler MyCustom );
-use parent qw( MyCustom );
+#use base qw( TAP::Parser::SourceHandler MyCustom );
+use base qw( MyCustom );
 
 TAP::Parser::IteratorFactory->register_handler(__PACKAGE__);
 

--- a/t/lib/TAP/Parser/SubclassTest.pm
+++ b/t/lib/TAP/Parser/SubclassTest.pm
@@ -10,7 +10,7 @@ use MyPerlSourceHandler;
 use MyGrammar;
 use MyResultFactory;
 
-use parent qw( TAP::Parser MyCustom );
+use base qw( TAP::Parser MyCustom );
 
 sub _default_source_class         {'MySourceHandler'}        # deprecated
 sub _default_perl_source_class    {'MyPerlSourceHandler'}    # deprecated

--- a/t/lib/Test/Builder.pm
+++ b/t/lib/Test/Builder.pm
@@ -75,7 +75,7 @@ Test::Builder - Backend for building test libraries
 
   package My::Test::Module;
   use Test::Builder;
-  use parent qw(Exporter);
+  use base qw(Exporter);
   @EXPORT = qw(ok);
 
   my $Test = Test::Builder->new;

--- a/t/lib/Test/Builder/Module.pm
+++ b/t/lib/Test/Builder/Module.pm
@@ -2,7 +2,7 @@ package Test::Builder::Module;
 
 use Test::Builder;
 
-use parent qw(Exporter);
+use base qw(Exporter);
 
 $VERSION = '0.72';
 

--- a/t/lib/Test/More.pm
+++ b/t/lib/Test/More.pm
@@ -17,7 +17,7 @@ our (@EXPORT, %EXPORT_TAGS, $TODO);
 our $VERSION = '0.72';
 $VERSION = eval $VERSION;    # make the alpha version come out as a number
 
-use parent qw(Test::Builder::Module);
+use base qw(Test::Builder::Module);
 @EXPORT = qw(ok use_ok require_ok
   is isnt like unlike is_deeply
   cmp_ok

--- a/t/lib/Test/Simple.pm
+++ b/t/lib/Test/Simple.pm
@@ -8,7 +8,7 @@ our @EXPORT;
 our $VERSION = '0.72';
 $VERSION = eval $VERSION;    # make the alpha version come out as a number
 
-use parent qw(Test::Builder::Module);
+use base qw(Test::Builder::Module);
 @EXPORT = qw(ok);
 
 my $CLASS = __PACKAGE__;

--- a/t/object.t
+++ b/t/object.t
@@ -15,7 +15,7 @@ can_ok( 'TAP::Object', '_croak' );
 {
 
     package TAP::TestObj;
-    use parent qw(TAP::Object);
+    use base qw(TAP::Object);
 
     sub _initialize {
         my $self = shift;

--- a/t/parse.t
+++ b/t/parse.t
@@ -804,7 +804,7 @@ END_TAP
 
     use strict;
 
-    use parent qw(TAP::Parser::Iterator);
+    use base qw(TAP::Parser::Iterator);
 
     sub next_raw {
         die 'this is the dying iterator';
@@ -899,7 +899,7 @@ END_TAP
 
     package TAP::Parser::WithBrokenState;
 
-    use parent qw( TAP::Parser );
+    use base qw( TAP::Parser );
 
     sub _make_state_table {
         return { INIT => { plan => { goto => 'FOO' } } };
@@ -936,7 +936,7 @@ END_TAP
 
     package TAP::Parser::WithBrokenIter;
 
-    use parent qw( TAP::Parser );
+    use base qw( TAP::Parser );
 
     sub _iter {return}
 

--- a/t/prove.t
+++ b/t/prove.t
@@ -17,7 +17,7 @@ use Text::ParseWords qw(shellwords);
 
 package FakeProve;
 
-use parent qw( App::Prove );
+use base qw( App::Prove );
 
 sub new {
     my $class = shift;

--- a/t/proverun.t
+++ b/t/proverun.t
@@ -69,7 +69,7 @@ BEGIN {
 
 package FakeProve;
 
-use parent qw( App::Prove );
+use base qw( App::Prove );
 
 sub new {
     my $class = shift;

--- a/t/results.t
+++ b/t/results.t
@@ -65,7 +65,7 @@ can_ok $factory, 'register_type';
     use strict;
     use warnings;
     our $VERSION;
-    use parent 'TAP::Parser::Result';
+    use base 'TAP::Parser::Result';
     TAP::Parser::ResultFactory->register_type( 'my_type' => __PACKAGE__ );
 }
 

--- a/t/testargs.t
+++ b/t/testargs.t
@@ -82,7 +82,7 @@ sub make_shell_test {
 
 package Test::Prove;
 
-use parent 'App::Prove';
+use base 'App::Prove';
 
 sub _runtests {
     my $self = shift;


### PR DESCRIPTION
This dist is used for testing all other modules, so it should avoid
having any non-core prerequisites.  Having parent as a prereq leads to a
circular dependency of parent -> Test::More -> Test::Harness.
