### PR TITLE
document that color is not default on Windows

### DIFF
--- a/bin/prove
+++ b/bin/prove
@@ -27,7 +27,7 @@ Boolean options:
  -b,  --blib            Add 'blib/lib' and 'blib/arch' to the path for
                         your tests
  -s,  --shuffle         Run the tests in random order.
- -c,  --color           Colored test output (default).
+ -c,  --color           Colored test output (usually default).
       --nocolor         Do not color test output.
       --count           Show the X/Y test count when not verbose
                         (default)
@@ -107,9 +107,9 @@ matching the pattern C<t/*.t>.
 
 =head2 Colored Test Output
 
-Colored test output using L<TAP::Formatter::Color> is the default, but 
-if output is not to a terminal, color is disabled. You can override this by 
-adding the C<--color> switch.
+Colored test output (using L<TAP::Formatter::Color>) is the default unless
+on a Windows platform, or if output is not to a terminal. You can force 
+colored output by adding the C<--color> switch.
 
 Color support requires L<Term::ANSIColor> on Unix-like platforms and
 L<Win32::Console> on windows. If the necessary module is not installed


### PR DESCRIPTION
Since colored output is not the default on Windows platforms,
this should be documented. I changed `(default)` to
`(usually default)` because there are two exceptions to the
rule of color being default, and I think it would be better
to direct users to read further documentation before assuming 
that color is always the default (and
`(default except on Windows or with non-terminal output)` was 
too long).
