### PR TITLE
Apply color to STDERR instead of STDOUT on Win32

### DIFF
--- a/lib/TAP/Formatter/Color.pm
+++ b/lib/TAP/Formatter/Color.pm
@@ -18,7 +18,7 @@ BEGIN {
             $NO_COLOR = $@;
         }
         else {
-            my $console = Win32::Console->new( STD_OUTPUT_HANDLE() );
+            my $console = Win32::Console->new( STD_ERROR_HANDLE() );
 
             # eval here because we might not know about these variables
             my $fg = eval '$FG_LIGHTGRAY';


### PR DESCRIPTION
Output wasn't colored on Win32 because the colors were being applied to STDOUT but the text to color (especially failures) appears on STDERR.
