### PR TITLE
Executable: use absolute path for executable tests

### DIFF
--- a/lib/TAP/Parser/SourceHandler/Executable.pm
+++ b/lib/TAP/Parser/SourceHandler/Executable.pm
@@ -3,6 +3,8 @@ package TAP::Parser::SourceHandler::Executable;
 use strict;
 use warnings;
 
+use File::Spec;
+
 use TAP::Parser::IteratorFactory   ();
 use TAP::Parser::Iterator::Process ();
 
@@ -107,7 +109,8 @@ sub make_iterator {
         @command = @{ $source->raw->{exec} || [] };
     }
     elsif ( $meta->{is_scalar} ) {
-        @command = ${ $source->raw };
+        @command = File::Spec->rel2abs( ${ $source->raw } )
+          if ${ $source->raw };
     }
     elsif ( $meta->{is_array} ) {
         @command = @{ $source->raw };


### PR DESCRIPTION
Convert executable tests to absolute paths.  Otherwise, if an executable
test file is given without any leading path components open/open3 will
search in PATH rather than local to the current working directory.

Signed-off-by: Andrew Gregory andrew.gregory.8@gmail.com
