### PR TITLE
Update URLs for the "testanything.org" website

### DIFF
--- a/HACKING.pod
+++ b/HACKING.pod
@@ -14,7 +14,8 @@ testers, documenters.)
 
 If you are looking for more information on how to I<use> TAP::Harness,
 you probably want
-L<http://testanything.org/wiki/index.php/TAP::Parser_Cookbook> instead.
+L<http://testanything.org/testing-with-tap/perl/tap::parser-cookbook.html>
+instead.
 
 =head1 Getting Started
 

--- a/lib/TAP/Harness/Beyond.pod
+++ b/lib/TAP/Harness/Beyond.pod
@@ -417,6 +417,10 @@ there's the tap-l[2] list. Finally there's a wiki dedicated to the
 Test Anything Protocol[3]. Contributions to the wiki, patches and
 suggestions are all welcome.
 
+=for comment
+  The URLs in [1] and [2] point to 404 pages. What are currently the
+  correct URLs?
+
 [1] L<http://www.hexten.net/mailman/listinfo/tapx-dev>
 [2] L<http://testanything.org/mailman/listinfo/tap-l>
 [3] L<http://testanything.org/>

--- a/lib/TAP/Parser.pm
+++ b/lib/TAP/Parser.pm
@@ -97,7 +97,7 @@ L<http://testanything.org>
 
 It includes the TAP::Parser Cookbook:
 
-L<http://testanything.org/wiki/index.php/TAP::Parser_Cookbook>
+L<http://testanything.org/testing-with-tap/perl/tap::parser-cookbook.html>
 
 =head1 METHODS
 


### PR DESCRIPTION
Hello,

Recently the testanything.org site changed it's layout and that broke some of the links in the Test-Harness POD files.

This commit tries to restore those URLs so that they point to the correct pages.

Unfortunately, in the TAP::Parser file there are two URLs for some mailing lists and none of them work as far as I can tell and also I couldn't find their current URLs. So I left a comment in there.