### PR TITLE
[FIX] accept YAML with trailing whitespace in header

### DIFF
--- a/lib/TAP/Parser/YAMLish/Reader.pm
+++ b/lib/TAP/Parser/YAMLish/Reader.pm
@@ -81,7 +81,7 @@ sub _read {
     my $line = $self->_peek;
 
     # Do we have a document header?
-    if ( $line =~ /^ --- (?: \s* (.+?) \s* )? $/x ) {
+    if ( $line =~ /^ --- (?: \s* (.+?)? \s* )? $/x ) {
         $self->_next;
 
         return $self->_read_scalar($1) if defined $1;    # Inline?

--- a/lib/TAP/Parser/YAMLish/Reader.pm
+++ b/lib/TAP/Parser/YAMLish/Reader.pm
@@ -206,7 +206,7 @@ sub _read_array {
             $line =~ s/-\s+//;
             push @$ar, $self->_read_hash( $line, $indent );
         }
-        elsif ( $line =~ /^ - \s* (.+?) \s* $/x ) {
+        elsif ( $line =~ /^ - \s* (\S.*?) \s* $/x ) {
             die "Unexpected start of YAMLish" if $line =~ /^---/;
             $self->_next;
             push @$ar, $self->_read_scalar($1);

--- a/t/yamlish.t
+++ b/t/yamlish.t
@@ -415,6 +415,25 @@ BEGIN {
             ],
             name => 'Regression: only_spaces'
         },
+        {   out => ['first','second'],
+            in  => [
+                '--- ',
+                '- first ',
+                '- second ',
+                '...'
+            ],
+            name => "Space after header for array",
+        },
+        {   out => {'key' => [{'value' => {'key2' => 'value2'}}]},
+            in  => [
+                '--- ',
+                'key: ',
+                '- value: ',
+                '    key2: value2 ',
+                '... '
+            ],
+            name => "Space after header for hash",
+        },
         {   out => [
                 undef,
                 {   'foo'  => 'bar',

--- a/t/yamlish.t
+++ b/t/yamlish.t
@@ -415,11 +415,13 @@ BEGIN {
             ],
             name => 'Regression: only_spaces'
         },
-        {   out => ['first','second'],
+        {   out => [{'first' => 1},{'second' => 2}],
             in  => [
                 '--- ',
-                '- first ',
-                '- second ',
+                '- ',
+                '  first: 1 ',
+                '- ',
+                '  second: 2 ',
                 '...'
             ],
             name => "Space after header for array",


### PR DESCRIPTION
YAML with a header that has trailing whitespace (i.e. '--- ' instead of
'---') is incorrectly treated as inline YAML. This fails since the
footer ('...') is not found on the same line. Whitespace after the
header is valid and needs to be treated correctly.

Please note: This patch only allows trailing whitespace after the header. The YAML specification does not require a newline after the three dashes so YAML that contains content on the same line as the header will still be wrongly rejected.
