### PR TITLE
add CI testing, missing META.yml on old perls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,41 @@
+language: perl
+notifications:
+  on_success: never
+  on_failure: always
+#  irc: "irc.perl.org#makemaker"
+  email: false
+sudo: false
+perl:
+  - "blead"
+  - "5.6.2"
+  - "5.8.1"
+  - "5.8.5"
+  - "5.8.7"
+  - "5.8.8"
+  - "5.8.9"
+  - "5.10.0"
+  - "5.10.1"
+  - "5.12.0"
+  - "5.12"
+  - "5.14.0"
+  - "5.14"
+  - "5.16.0"
+  - "5.16"
+  - "5.18.0"
+  - "5.18"
+  - "5.20"
+matrix:
+  allow_failures:
+    - perl: "blead"
+    - perl: "5.6.2"
+before_install:
+  - git clone git://github.com/haarg/perl-travis-helper ~/perl-travis-helper
+  - source ~/perl-travis-helper/init
+  - build-perl
+  - perl -V
+install:
+  - true
+script:
+  - perl Makefile.PL
+  - make test
+  - make disttest

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,15 @@
+version: 1.0.{build}
+skip_tags: true
+clone_depth: 1
+init:
+  - git config --global core.autocrlf input
+# Mingw and Cygwin now builtin: http://www.appveyor.com/updates/2015/05/30
+#os: MinGW
+
+install:
+  - perl -V
+  - C:\MinGW\bin\mingw32-make -v
+  - echo %PATH%
+build_script:
+#do not let gmake find sh.exe (usually part of git for windows) in %PATH%
+- set PATH=C:\windows\system32;C:\Perl\site\bin;C:\Perl\bin;C:\windows;C:\MinGW\bin; && set ACTIVEPERL_CONFIG_DISABLE=1 && perl Makefile.PL MAKE=gmake && mingw32-make test


### PR DESCRIPTION
Appveyor passes https://ci.appveyor.com/project/bulk88/test-harness/build/1.0.4 travis does not https://travis-ci.org/bulk88/Test-Harness/builds/125358698 . IDK what to do about travis failing. I think either require a min perl version, require min core module versions, or should T::H be fixed (add a META.yml)?
