### PR TITLE
CVE-2016-1238: avoid loading optional modules from default .

### DIFF
--- a/bin/prove
+++ b/bin/prove
@@ -1,5 +1,6 @@
 #!/usr/bin/perl -w
 
+BEGIN { pop @INC if $INC[-1] eq '.' }
 use strict;
 use warnings;
 use App::Prove;


### PR DESCRIPTION
App::Prove (and hence prove) attempts to load plugins under both
the App::Prove::Plugin namespace and under the base namespace.

If a plugin is only available under the base namespace, and a user runs
prove from a world-writable directory such as /tmp, an attacker can
App/Prove/Plugin/PluginName.pm to run code as the user running prove.
