### PR TITLE
fix and simplify MSWin32 colorization

### DIFF
--- a/bin/prove
+++ b/bin/prove
@@ -108,12 +108,12 @@ matching the pattern C<t/*.t>.
 
 =head2 Colored Test Output
 
-Colored test output using L<TAP::Formatter::Color> is the default, but 
-if output is not to a terminal, color is disabled. You can override this by 
+Colored test output using L<TAP::Formatter::Color> is the default, but
+if output is not to a terminal, color is disabled. You can override this by
 adding the C<--color> switch.
 
-Color support requires L<Term::ANSIColor> on Unix-like platforms and
-L<Win32::Console::ANSI> on windows. If the necessary module is not installed
+Color support requires L<Term::ANSIColor> and, on windows platforms, also
+L<Win32::Console::ANSI>. If the necessary module(s) are not installed
 colored output will not be available.
 
 =head2 Exit Code

--- a/bin/prove
+++ b/bin/prove
@@ -113,7 +113,7 @@ if output is not to a terminal, color is disabled. You can override this by
 adding the C<--color> switch.
 
 Color support requires L<Term::ANSIColor> on Unix-like platforms and
-L<Win32::Console> on windows. If the necessary module is not installed
+L<Win32::Console::ANSI> on windows. If the necessary module is not installed
 colored output will not be available.
 
 =head2 Exit Code

--- a/lib/App/Prove.pm
+++ b/lib/App/Prove.pm
@@ -279,7 +279,7 @@ sub _help {
 sub _color_default {
     my $self = shift;
 
-    return -t STDOUT && !$ENV{HARNESS_NOTTY} && !IS_WIN32;
+    return -t STDOUT && !$ENV{HARNESS_NOTTY};
 }
 
 sub _get_args {

--- a/lib/TAP/Formatter/Color.pm
+++ b/lib/TAP/Formatter/Color.pm
@@ -55,7 +55,7 @@ in color.  Passing tests are printed in green.  Failing tests are in red.
 Skipped tests are blue on a white background and TODO tests are printed in
 white.
 
-If L<Term::ANSIColor> cannot be found (or L<Win32::Console::ANSI> if running
+If L<Term::ANSIColor> cannot be found (and L<Win32::Console::ANSI> if running
 under Windows) tests will be run without color.
 
 =head1 SYNOPSIS

--- a/lib/TAP/Formatter/Color.pm
+++ b/lib/TAP/Formatter/Color.pm
@@ -12,56 +12,24 @@ my $NO_COLOR;
 BEGIN {
     $NO_COLOR = 0;
 
+    eval 'use Term::ANSIColor';
+    if ($@) {
+        $NO_COLOR = $@;
+    };
     if (IS_WIN32) {
-        eval 'use Win32::Console';
+        eval 'use Win32::Console::ANSI';
         if ($@) {
             $NO_COLOR = $@;
         }
-        else {
-            my $console = Win32::Console->new( STD_OUTPUT_HANDLE() );
-
-            # eval here because we might not know about these variables
-            my $fg = eval '$FG_LIGHTGRAY';
-            my $bg = eval '$BG_BLACK';
-
-            *set_color = sub {
-                my ( $self, $output, $color ) = @_;
-
-                my $var;
-                if ( $color eq 'reset' ) {
-                    $fg = eval '$FG_LIGHTGRAY';
-                    $bg = eval '$BG_BLACK';
-                }
-                elsif ( $color =~ /^on_(.+)$/ ) {
-                    $bg = eval '$BG_' . uc($1);
-                }
-                else {
-                    $fg = eval '$FG_' . uc($color);
-                }
-
-                # In case of colors that aren't defined
-                $self->set_color('reset')
-                  unless defined $bg && defined $fg;
-
-                $console->Attr( $bg | $fg );
-            };
-        }
-    }
-    else {
-        eval 'use Term::ANSIColor';
-        if ($@) {
-            $NO_COLOR = $@;
-        }
-        else {
-            *set_color = sub {
-                my ( $self, $output, $color ) = @_;
-                $output->( color($color) );
-            };
-        }
-    }
+    };
 
     if ($NO_COLOR) {
         *set_color = sub { };
+    } else {
+        *set_color = sub {
+            my ( $self, $output, $color ) = @_;
+            $output->( color($color) );
+        };
     }
 }
 
@@ -87,7 +55,7 @@ in color.  Passing tests are printed in green.  Failing tests are in red.
 Skipped tests are blue on a white background and TODO tests are printed in
 white.
 
-If L<Term::ANSIColor> cannot be found (or L<Win32::Console> if running
+If L<Term::ANSIColor> cannot be found (or L<Win32::Console::ANSI> if running
 under Windows) tests will be run without color.
 
 =head1 SYNOPSIS

--- a/lib/TAP/Formatter/Color.pm
+++ b/lib/TAP/Formatter/Color.pm
@@ -12,7 +12,7 @@ my $NO_COLOR;
 BEGIN {
     $NO_COLOR = 0;
 
-    eval 'use Term::ANSIColor';
+    eval 'require Term::ANSIColor';
     if ($@) {
         $NO_COLOR = $@;
     };
@@ -28,7 +28,7 @@ BEGIN {
     } else {
         *set_color = sub {
             my ( $self, $output, $color ) = @_;
-            $output->( color($color) );
+            $output->( Term::ANSIColor::color($color) );
         };
     }
 }


### PR DESCRIPTION
- rationale: using Win32::Console::ANSI simplifies the code and improves Win32 outputs

<hr/>
- simplified usage ~ Win32::Console::ANSI is fire-and-forget
  - once loaded, use Term::ANSIColor without regard for platform
- fixes incorrect color 'reset' behavior
  - Win32::Color::ANSI resets correctly to the prior default color attribute set
  - bug due to incorrect assumption that LIGHTGRAY on BLACK are always the default color attributes
- fixes [GH#26](https://github.com/Perl-Toolchain-Gang/Test-Harness/issues/26)
  - Win32::Console::ANSI works for all output (no tie to a specific output handle)
  - [PR#34](https://github.com/Perl-Toolchain-Gang/Test-Harness/pull/34) is not needed

<hr/>
## Notes

Here's an example of output reset breakage ...
- baseline

<img width="839" alt="2016-09-11 8" src="https://cloud.githubusercontent.com/assets/80132/18419659/aa7a8a98-7825-11e6-82c4-7f0a053d8e07.png">
- with PR

<img width="839" alt="2016-09-11 7" src="https://cloud.githubusercontent.com/assets/80132/18419797/e0e2ed84-7828-11e6-8c28-5d6475d1ce76.png">

Notably, CPAN also uses Win32::Console::ANSI and the color output is correct (no aberrant color resets) (see [CPAN/Shell.pm#L1483](https://github.com/andk/cpanpm/blob/a0cf576cffce258f223a055a54e173418c195699/lib/CPAN/Shell.pm#L1483)).
