### PR TITLE
Fix t/regression.t for old portable Strawberry Perl

### DIFF
--- a/t/regression.t
+++ b/t/regression.t
@@ -3306,6 +3306,11 @@ sub analyze_test {
           "$test/$count We should have a result for $desc";
         while ( my ( $method, $answer ) = each %$expected ) {
 
+            # Skip spurious warnings captured on old Strawberry Perls with
+            # newer CPAN::Meta::YAML
+            next if ref $result eq "TAP::Parser::Result::Unknown"
+                && $result->raw =~ m{CPAN::Meta::YAML found a duplicate key};
+
             if ( my $handler = $HANDLER_FOR{ $answer || '' } ) {    # yuck
                 ok $handler->( $result->$method() ),
                   "... and $method should return a reasonable value ($test/$count)";


### PR DESCRIPTION
Old portable Strawberry Perls had a duplicate key in the portable.perl
YAML file.  With newer CPAN::Meta::YAML, this issues warnings on every
perl execution, which caused failures in the Test::Harness
t/regression.t test.

This commit skips parser results in testing if they appear to be from
such a situation.