### PR TITLE
Spelling fix: than -> then

### DIFF
--- a/lib/TAP/Parser/Scheduler.pm
+++ b/lib/TAP/Parser/Scheduler.pm
@@ -87,7 +87,7 @@ Here are some examples:
                ],
     }
 
-    # Run some  startup tests in sequence, then some parallel tests than some
+    # Run some  startup tests in sequence, then some parallel tests then some
     # teardown tests in sequence.
     {
         seq => [


### PR DESCRIPTION
Small spelling / usage fix in POD docs.