### PR TITLE
set PERL_USE_UNSAFE_INC in TAP::Harness too

### DIFF
--- a/lib/TAP/Harness.pm
+++ b/lib/TAP/Harness.pm
@@ -544,6 +544,7 @@ Returns a L<TAP::Parser::Aggregator> containing the test results.
 sub runtests {
     my ( $self, @tests ) = @_;
 
+    local $ENV{PERL_USE_UNSAFE_INC} = 1 if not exists $ENV{PERL_USE_UNSAFE_INC};
     my $aggregate = $self->_construct( $self->aggregator_class );
 
     $self->_make_callback( 'before_runtests', $aggregate );


### PR DESCRIPTION
Hi. Test::Harness 3.38 works correctly with perl without . in @ INC when we run make test, but doesn't work well when we run prove -b t/ etc because App::Prove uses TAP::Harness::Env which uses TAP::Harness::runtests (instead of already-fixed Test::Harness) by default. This PR sets PERL_USE_UNSAFE_INC there to fix the issue.

( Sorry, previous PR was made to the master. )