### PR TITLE
Clarify behaviour of TAP::Parser::Aggregator->all_passed

### DIFF
--- a/lib/TAP/Parser/Aggregator.pm
+++ b/lib/TAP/Parser/Aggregator.pm
@@ -250,6 +250,8 @@ sub elapsed_timestr {
 =head3 C<all_passed>
 
 Return true if all the tests passed and no parse errors were detected.
+Note that this method will return false if no tests were run, such as
+when all of them were skipped.
 
 =cut
 


### PR DESCRIPTION
Had a bug in my code because I assumed `->all_passed` was the same as "everything is good". But this method returns false if all tests were skipped, like with `plan skip_all => 'some reason'`
