### PR TITLE
prove: add a --statefile=<path> option to customize the .prove file

### DIFF
--- a/bin/prove
+++ b/bin/prove
@@ -72,6 +72,7 @@ Options that take arguments:
  -a,  --archive out.tgz Store the resulting TAP in an archive file.
  -j,  --jobs N          Run N test jobs in parallel (try 9.)
       --state=opts      Control prove's persistent state.
+      --statefile=file  Use `file` instead of `.prove` for state
       --rc=rcfile       Process options from rcfile
       --rules           Rules for parallel vs sequential processing.
 

--- a/lib/App/Prove.pm
+++ b/lib/App/Prove.pm
@@ -59,6 +59,7 @@ BEGIN {
       verbose warnings_fail warnings_warn show_help show_man show_version
       state_class test_args state dry extensions ignore_exit rules state_manager
       normalize sources tapversion trap
+      statefile
     );
     __PACKAGE__->mk_methods(@ATTR);
 }
@@ -229,6 +230,7 @@ sub process_args {
             'M=s@'         => $self->{modules},
             'P=s@'         => $self->{plugins},
             'state=s@'     => $self->{state},
+            'statefile=s'  => \$self->{statefile},
             'directives'   => \$self->{directives},
             'h|help|?'     => \$self->{show_help},
             'H|man'        => \$self->{show_man},
@@ -479,7 +481,7 @@ sub run {
 
     unless ( $self->state_manager ) {
         $self->state_manager(
-            $self->state_class->new( { store => STATE_FILE } ) );
+            $self->state_class->new( { store => $self->statefile || STATE_FILE } ) );
     }
 
     if ( $self->show_help ) {


### PR DESCRIPTION
It's inconvenient in some setups to have the .prove file be in the t/
directory, e.g. on Travis instances there's a use-case for caching the
.prove file across runs, so that you can run with
--state=failed,slow,save.

However doing so requires a Travis feature where you cache the t/
directory across runs, which is an overkill and often not what you
want, e.g. if the t/ directory will contain generated test data.

The Git project is impacted by this, currently we use a small hack to
symlink .prove to another directory:
https://github.com/git/git/commit/6272ed3194

It would be easier to just supply
--statefile=$HOME/travis-cache/prove-state, this change allows for
that.