### PR TITLE
Avoid non-deterministic source handling, make a SourceHandler tie an error.

### DIFF
--- a/lib/TAP/Parser/IteratorFactory.pm
+++ b/lib/TAP/Parser/IteratorFactory.pm
@@ -265,7 +265,7 @@ sub detect_source {
     # if multiple handlers can handle it, choose the most confident one
     my @handlers = (
         map    {$_}
-          sort { $handlers{$a} cmp $handlers{$b} }
+          sort { $handlers{$a} <=> $handlers{$b} }
           keys %handlers
     );
 

--- a/lib/TAP/Parser/IteratorFactory.pm
+++ b/lib/TAP/Parser/IteratorFactory.pm
@@ -269,6 +269,15 @@ sub detect_source {
           keys %handlers
     );
 
+    # Check for a tie.
+    if( @handlers > 1 &&
+        $handlers{$handlers[0]} == $handlers{$handlers[1]}
+    ) {
+        my $filename = $source->meta->{file}{basename};
+        die("There is a tie between $handlers[0] and $handlers[1].\n".
+            "Both voted $handlers{$handlers[0]} on $filename.\n");
+    }
+
     # this is really useful for debugging handlers:
     if ( $ENV{TAP_HARNESS_SOURCE_FACTORY_VOTES} ) {
         warn(

--- a/t/iterator_factory.t
+++ b/t/iterator_factory.t
@@ -10,7 +10,7 @@ BEGIN {
 use strict;
 use warnings;
 
-use Test::More tests => 42;
+use Test::More tests => 44;
 
 use IO::File;
 use File::Spec;
@@ -124,6 +124,9 @@ my @sources = (
         handler  => 'TAP::Parser::SourceHandler::Handle',
         iterator => 'TAP::Parser::Iterator::Stream',
     },
+    {   file     => 'test.tap',
+        tie      => 1,
+    },
 );
 
 for my $test (@sources) {
@@ -141,10 +144,18 @@ for my $test (@sources) {
     my $source   = TAP::Parser::Source->new->raw( ref($raw) ? $raw : \$raw );
     my $iterator = eval { $sf->make_iterator($source) };
     my $error    = $@;
-    ok( !$error, "$name: no error on make_iterator" );
-    diag($error) if $error;
+    
+    if( $test->{tie} ) {
+        like(
+            $error, qr{^There is a tie.*Both voted .* on $test->{file}}ms,
+            "$name: votes tied"
+        )
+    }
+    else {
+        ok( !$error, "$name: no error on make_iterator" );
+        diag($error) if $error;
+    }
 
-    #    isa_ok( $iterator, $test->{iterator}, $name );
     is( $sf->_last_handler, $test->{handler}, $name );
 }
 

--- a/t/lib/MyFileSourceHandler.pm
+++ b/t/lib/MyFileSourceHandler.pm
@@ -20,7 +20,7 @@ sub can_handle {
     my $class = shift;
     $class->SUPER::can_handle(@_);
     $CAN_HANDLE++;
-    return $class;
+    return 1;
 }
 
 sub make_iterator {

--- a/t/source_tests/test.tap
+++ b/t/source_tests/test.tap
@@ -1,0 +1,8 @@
+#!/usr/bin/perl
+
+# This looks equally like a TAP file and a Perl executable.
+
+print <<'END_TESTS';
+1..1
+ok 1 - source.pl
+END_TESTS


### PR DESCRIPTION
If two SourceHandlers vote with the same confidence, TAP::Parser::IteratorFactory will choose one at random. This makes knowing how the harness will interpret a source file non-deterministic.

Rather than try to guess, this patch makes confidence ties an error. The user can then fix it to make the selection process deterministic again.

See http://stackoverflow.com/questions/44101948/prove-returns-inconsistent-test-results-with-testmore-and-tap-extension/44102160 for this in the wild.