### PR TITLE
Allow comments before plan

### DIFF
--- a/lib/TAP/Formatter/Console/Session.pm
+++ b/lib/TAP/Formatter/Console/Session.pm
@@ -124,7 +124,7 @@ sub _closures {
             # is false - so it's safe to only set them here unless that
             # relationship changes.
 
-            if ( !$plan ) {
+            if ( !$plan || !$parser->tests_run ) {
                 my $planned = $parser->tests_planned || '?';
                 $plan = "/$planned ";
             }


### PR DESCRIPTION
Don't permanently cache the current plan until the first test, in case there are any leading comments (meaning we don't yet have a plan so caching it might be premature).