### PR TITLE
Avoid waiting on a single test for output

### DIFF
--- a/lib/TAP/Parser/Iterator/Process.pm
+++ b/lib/TAP/Parser/Iterator/Process.pm
@@ -249,6 +249,10 @@ sub _next {
                         }
                         elsif ( $fh == $err ) {
                             print STDERR $chunk;    # echo STDERR
+
+                            # Return to avoid blocking other tests (when
+                            # running in parallel).
+                            return '';
                         }
                         else {
                             $chunk   = $partial . $chunk;


### PR DESCRIPTION
When running Perl's prove with multiple jobs (-j #), the running jobs can
get stuck waiting on a single test to complete.  This occurs when a test
outputs to STDERR, but does not output to STDOUT for some time after that.
The parser iterator gets stuck waiting for can_read() on that one test,
instead of looking at all of the running tests.

Avoid this slowdown by returning, potentially early, to ensure nothing
holds up the other tests.

---

To view the problem mentioned, create a directory an populate it with the following files:

`00_blocker.t`:
```perl
use Test::More tests => 1;
print STDERR "Error message\n";
sleep 10;
pass();
```

`01_blocked.t`:
```perl
use Test::More tests => 1;
select undef, undef, undef, 0.009;  # Wait 9ms
pass();
```

Then make 98 copies of the blocked test, to emphasize the time difference:
```sh
 for i in $(seq -w 2 99); do ln -s 01_blocked.t ${i}_blocked.t; done
```

Run `prove *_blocked.t`.  On my system, this takes about 7 wallclock seconds.

Run `prove -j 2 *_blocked.t`.  With the parallelization of similar files, we would expect this to take about half the time.  And, indeed, on my system it takes about 3 wallclock seconds.

If we were to add `00_blocker.t` to the parallelized `prove -j 2` run, we would expect it to start first and, with its 10 second sleep, it would force the other 99 tests to run sequentially.  Thus, on my system it would take 10 seconds to run (as the max of 10 and 7 seconds).

Running `prove --timer -j 2 *.t` before this fix actually takes 13 seconds (or 10 + 3 seconds) on my system, because of the blocking nature.  However, after the fix, it runs for 10 seconds, as expected.
