### PR TITLE
only space-quote executable if has spaces and is executable

### DIFF
--- a/lib/TAP/Parser/Iterator/Process.pm
+++ b/lib/TAP/Parser/Iterator/Process.pm
@@ -288,6 +288,7 @@ sub _next {
         }
         else {
             return sub {
+                local $/ = "\n"; # to ensure lines
                 if ( defined( my $line = <$out> ) ) {
                     chomp $line;
                     return $line;

--- a/lib/TAP/Parser/Iterator/Process.pm
+++ b/lib/TAP/Parser/Iterator/Process.pm
@@ -169,8 +169,10 @@ sub _initialize {
     }
     else {
         $err = '';
+        my $exec = shift @command;
+        $exec = qq{"$exec"} if $exec =~ /\s/ and -x $exec;
         my $command
-          = join( ' ', map { $_ =~ /\s/ ? qq{"$_"} : $_ } @command );
+          = join( ' ', $exec, map { $_ =~ /\s/ ? qq{"$_"} : $_ } @command );
         open( $out, "$command|" )
           or die "Could not execute ($command): $!";
     }


### PR DESCRIPTION
This is necessary for when the Perl executable has spaces in its path.