### PR TITLE
mention of TEST_VERBOSE

### DIFF
--- a/bin/prove
+++ b/bin/prove
@@ -23,7 +23,7 @@ prove - Run tests through a TAP harness.
 
 Boolean options:
 
- -v,  --verbose         Print all test lines.
+ -v,  --verbose         Print all test lines.  Also sets TEST_VERBOSE
  -l,  --lib             Add 'lib' to the path for your tests (-Ilib).
  -b,  --blib            Add 'blib/lib' and 'blib/arch' to the path for
                         your tests


### PR DESCRIPTION
TEST_VERBOSE is still set by prove --verbose but no more documented.
see https://rt.cpan.org/Ticket/Display.html?id=129033 for more details
thanks