### PR TITLE
Don't process --rc/--norc options from test arguments

### DIFF
--- a/lib/App/Prove.pm
+++ b/lib/App/Prove.pm
@@ -136,6 +136,16 @@ sub add_rc_file {
     close RC;
 }
 
+sub _extract_test_arguments {
+    my ($self, $args) = @_;
+
+    if ( defined( my $stop_at = _first_pos( '::', @$args ) ) ) {
+        my @test_args = splice @$args, $stop_at;
+        shift @test_args;
+        $self->{test_args} = \@test_args;
+    }
+}
+
 =head3 C<process_args>
 
     $prove->process_args(@args);
@@ -174,11 +184,7 @@ sub process_args {
 
     # Everything after the arisdottle '::' gets passed as args to
     # test programs.
-    if ( defined( my $stop_at = _first_pos( '::', @args ) ) ) {
-        my @test_args = splice @args, $stop_at;
-        shift @test_args;
-        $self->{test_args} = \@test_args;
-    }
+    $self->_extract_test_arguments( \@args );
 
     # Grab options from RC files
     $self->add_rc_file($_) for grep -f, @rc;

--- a/lib/App/Prove.pm
+++ b/lib/App/Prove.pm
@@ -163,6 +163,10 @@ sub process_args {
     my @rc = RC_FILE;
     unshift @rc, glob '~/' . RC_FILE if IS_UNIXY;
 
+    # Everything after the arisdottle '::' gets passed as args to
+    # test programs - even their own --rc/--norc
+    $self->_extract_test_arguments( \@_ );
+
     # Preprocess meta-args.
     my @args;
     while ( defined( my $arg = shift ) ) {
@@ -181,10 +185,6 @@ sub process_args {
             push @args, $arg;
         }
     }
-
-    # Everything after the arisdottle '::' gets passed as args to
-    # test programs.
-    $self->_extract_test_arguments( \@args );
 
     # Grab options from RC files
     $self->add_rc_file($_) for grep -f, @rc;

--- a/lib/App/Prove/State.pm
+++ b/lib/App/Prove/State.pm
@@ -448,9 +448,9 @@ sub observe_test {
     my $fail = scalar( $parser->failed ) + ( $parser->has_problems ? 1 : 0 );
     my $todo = scalar( $parser->todo );
     my $start_time = $parser->start_time;
-    my $end_time   = $parser->end_time,
+    my $end_time   = $parser->end_time;
 
-      my $test = $self->results->test($name);
+	my $test = $self->results->test($name);
 
     $test->sequence( $self->{seq}++ );
     $test->generation( $self->results->generation );

--- a/t/testargs.t
+++ b/t/testargs.t
@@ -23,7 +23,7 @@ my $test = File::Spec->catfile(
 
 my @test = ( [ perl => $test ], make_shell_test($test) );
 
-plan tests => @test * 8 + 5;
+plan tests => @test * 8 + 6;
 
 sub echo_ok {
     my ( $type, $options ) = ( shift, shift );
@@ -105,6 +105,16 @@ package main;
     my $log = $app->get_run_log;
     is_deeply $log->[0]->[0]->{test_args}, [ 'one', 'two', 'huh' ],
       "prove args match";
+}
+
+{
+    my $app = Test::Prove->new;
+
+    $app->process_args( '--norc', $test, '::', 'one', 'two', 'huh', '--rc' );
+    $app->run();
+    my $log = $app->get_run_log;
+    is_deeply $log->[0]->[0]->{test_args}, [ 'one', 'two', 'huh', '--rc' ],
+      "should not extract  --rc from test arguments";
 }
 
 sub bigness {


### PR DESCRIPTION
every argument after '::' should be passed to test but meta arguments
are not, making usage like following little bit hard to understand

```
  prove --state save --rc my-rc-file :: --url https://some/url --rc
```