### PR TITLE
Let the aggregator finish gracefully after bailout

### DIFF
--- a/lib/TAP/Harness.pm
+++ b/lib/TAP/Harness.pm
@@ -555,8 +555,11 @@ sub runtests {
         $self->_make_callback( 'after_runtests', $aggregate );
     };
     my $run = sub {
-        $self->aggregate_tests( $aggregate, @tests );
+        my $bailout;
+        eval { $self->aggregate_tests( $aggregate, @tests ); 1 }
+            or do { $bailout = $@ || 'unknown_error' };
         $finish->();
+        die $bailout if defined $bailout;
     };
 
     if ( $self->trap ) {
@@ -595,7 +598,12 @@ sub _after_test {
 }
 
 sub _bailout {
-    my ( $self, $result ) = @_;
+    my ( $self, $result, $parser, $session, $aggregate, $job ) = @_;
+
+    $self->finish_parser( $parser, $session );
+    $self->_after_test( $aggregate, $job, $parser );
+    $job->finish;
+
     my $explanation = $result->explanation;
     die "FAILED--Further testing stopped"
       . ( $explanation ? ": $explanation\n" : ".\n" );
@@ -625,7 +633,8 @@ sub _aggregate_parallel {
             my ( $session, $job ) = @$stash;
             if ( defined $result ) {
                 $session->result($result);
-                $self->_bailout($result) if $result->is_bailout;
+                $self->_bailout($result, $parser, $session, $aggregate, $job )
+                    if $result->is_bailout;
             }
             else {
 
@@ -657,7 +666,7 @@ sub _aggregate_single {
                 # Keep reading until input is exhausted in the hope
                 # of allowing any pending diagnostics to show up.
                 1 while $parser->next;
-                $self->_bailout($result);
+                $self->_bailout($result, $parser, $session, $aggregate, $job );
             }
         }
 

--- a/t/harness-bailout.t
+++ b/t/harness-bailout.t
@@ -1,55 +1,231 @@
-#!perl
-
+package My::Aggregator;
 use strict;
 use warnings;
-use File::Spec;
 
-BEGIN {
-    *CORE::GLOBAL::exit = sub { die '!exit called!' };
+sub new {
+	my ($class) = @_;
+
+	my $self = { results => {} };
+	return bless( $self, $class );
 }
 
-use TAP::Harness;
-use Test::More;
+sub start {}
+sub stop {}
 
-my @jobs = (
-    {   name => 'sequential',
-        args => { verbosity => -9 },
-    },
-    {   name => 'parallel',
-        args => { verbosity => -9, jobs => 2 },
-    },
+sub add {
+	my ($self, $description, $parser) = @_;
+	die "Test '$description' run twice" if exists $self->{results}{$description};
+	$self->{results}{$description} = $parser;
+}
+
+1;
+
+package My::Session;
+use strict;
+use warnings;
+
+sub new {
+	my ($class, %args) = @_;
+
+	my $self = { %args };
+	return bless( $self, $class );
+}
+
+sub result {
+	my ($self, $result) = @_;
+	return $self->{result} = $result || $self->{result};
+}
+
+sub close_test {
+	shift->{closed} = 1;
+}
+
+1;
+
+package My::Formatter;
+use strict;
+use warnings;
+
+sub new {
+	my ($class, $args) = @_;
+
+	my $self = { %$args };
+	return bless( $self, $class );
+}
+
+sub summary {
+	my ($self, $aggregator, $interrupted) = @_;
+
+	return sprintf(
+		"My %sinterrupted formatter summary for %s",
+		$interrupted ? '' : 'un',
+		ref $aggregator
+	);
+}
+sub verbosity { 0; }
+sub prepare {};
+sub open_test {
+	my ($self, $test_name, $parser) = @_;
+
+	return My::Session->new( name => $test_name, parser => $parser );
+};
+
+1;
+package My::Multiplexer;
+use strict;
+use warnings;
+
+sub new {
+	my ($class) = @_;
+
+	my $self = { parsers => [] };
+	return bless( $self, $class );
+}
+
+sub add {
+	my ( $self, $parser, $stash ) = @_;
+	push @{ $self->{parsers} }, [ $parser, $stash ];
+}
+
+sub parsers { return scalar @{ shift->{parsers} }; }
+
+sub next {
+	my ($self) = @_;
+
+	return unless $self->parsers;
+	my ($parser, $stash) = @{ $self->{parsers}->[0] };
+	my $result = $parser->next;
+	shift @{ $self->{parsers} } unless $result;
+	return ( $parser, $stash, $result );
+}
+
+1;
+
+package My::Result;
+use strict;
+use warnings;
+
+sub new {
+	my ($class, %args) = @_;
+
+	my $self = { %args };
+	return bless( $self, $class );
+}
+
+sub is_bailout {
+	return ( (shift->{source} || '') =~ '^bailout' );
+}
+
+sub explanation {
+	return shift->{source};
+}
+
+1;
+
+package My::Parser;
+use strict;
+use warnings;
+
+sub new {
+	my ($class, $args) = @_;
+
+	my $self = { %$args, nexted => 0 };
+	return bless( $self, $class );
+}
+
+sub next {
+	my ($self) = @_;
+	return if $self->{nexted};
+	$self->{nexted} = 1;
+	return My::Result->new( source => $self->{source} );
+}
+
+sub delete_spool {}
+
+1;
+
+package My::Job;
+use strict;
+use warnings;
+
+our @finished_jobs;
+
+sub new {
+	my ($class, %args) = @_;
+
+	my $self = { %args };
+	return bless( $self, $class );
+}
+sub description { shift->{description} };
+sub filename { shift->{filename} };
+sub is_spinner {};
+sub as_array_ref { return [ shift->description ] };
+sub finish { push @finished_jobs, shift->filename; }
+
+1;
+
+package My::Scheduler;
+use strict;
+use warnings;
+
+sub new {
+	my ($class, %args) = @_;
+
+	my @jobs = map
+		{ My::Job->new( filename => $_->[0], description => $_->[1] ) }
+		@{ delete( $args{tests} ) || [] };
+
+	my $self = { %args, jobs => [ @jobs ] };
+	return bless( $self, $class );
+}
+
+sub get_all { @{ shift->{jobs} || [] }; }
+sub get_job { shift( @{ shift->{jobs} } ); }
+1;
+
+package main;
+use strict;
+use warnings;
+
+use Test::More;
+use TAP::Harness;
+
+sub create_harness {
+	my (%arg) = @_;
+
+	return TAP::Harness->new({
+		aggregator_class => 'My::Aggregator',
+		formatter_class => 'My::Formatter',
+		multiplexer_class => 'My::Multiplexer',
+		parser_class => 'My::Parser',
+		scheduler_class => 'My::Scheduler',
+		jobs => $arg{jobs} || 1,
+	});
+}
+
+my @after_test_callbacks;
+
+my $harness = create_harness( jobs => 1 );
+$harness->callback( after_test => sub { push @after_test_callbacks, $_[0] } );
+eval { $harness->runtests( qw( no-bailout bailout not-executed ) ); };
+my $err = $@;
+like $err, qr/FAILED--Further testing stopped: bailout/;
+
+$harness = create_harness( jobs => 2 );
+$harness->callback( after_test => sub { push @after_test_callbacks, $_[0] } );
+eval { $harness->runtests( qw( no-bailout-parallel bailout-parallel not-executed-parallel ) ); };
+$err = $@;
+like $err, qr/FAILED--Further testing stopped: bailout/;
+
+is_deeply(
+	[ @after_test_callbacks ],
+	[ [ 'no-bailout' ], [ 'bailout' ], [ 'no-bailout-parallel' ], [ 'bailout-parallel' ],  ],
+	'After test callbacks called OK'
+);
+is_deeply(
+	[ @My::Job::finished_jobs ],
+	[ 'no-bailout', 'bailout', 'no-bailout-parallel', 'bailout-parallel', ],
+	'Jobs finished OK'
 );
 
-plan tests => @jobs * 2;
-
-for my $test (@jobs) {
-    my $name    = $test->{name};
-    my $args    = $test->{args};
-    my $harness = TAP::Harness->new($args);
-    eval {
-        local ( *OLDERR, *OLDOUT );
-        open OLDERR, '>&STDERR' or die $!;
-        open OLDOUT, '>&STDOUT' or die $!;
-        my $devnull = File::Spec->devnull;
-        open STDERR, ">$devnull" or die $!;
-        open STDOUT, ">$devnull" or die $!;
-
-        $harness->runtests(
-            File::Spec->catfile(
-                't',
-                'sample-tests',
-                'bailout'
-            )
-        );
-
-        open STDERR, '>&OLDERR' or die $!;
-        open STDOUT, '>&OLDOUT' or die $!;
-    };
-    my $err = $@;
-    unlike $err, qr{!exit called!}, "$name: didn't exit";
-    like $err, qr{FAILED--Further testing stopped: GERONIMMMOOOOOO!!!},
-      "$name: bailout message";
-}
-
-# vim:ts=2:sw=2:et:ft=perl
-
+done_testing();


### PR DESCRIPTION
Some derived harnesses, e.g. T:H:JUnit, do all their meaningful work
(e.g. formatting aggregated test results into XML) after the
aggregate_tests finishes normally. Bailing out prevented this
meaningful work to be finished, causing the test results, including
potential clues to why the test bailed out in first place, to be thrown
away.