### PR TITLE
TAP::Harness: Move timer initialization

### DIFF
--- a/lib/TAP/Harness.pm
+++ b/lib/TAP/Harness.pm
@@ -627,6 +627,10 @@ sub _aggregate_parallel {
 
             my ( $parser, $session ) = $self->make_parser($job);
             $mux->add( $parser, [ $session, $job ] );
+
+            # The job has started: begin the timers
+            $parser->start_time( $parser->get_time );
+            $parser->start_times( $parser->get_times );
         }
 
         if ( my ( $parser, $stash, $result ) = $mux->next ) {

--- a/lib/TAP/Parser.pm
+++ b/lib/TAP/Parser.pm
@@ -1384,8 +1384,8 @@ sub _iter {
     my $state       = 'INIT';
     my $state_table = $self->_make_state_table;
 
-    $self->start_time( $self->get_time );
-    $self->start_times( $self->get_times );
+    $self->start_time( $self->get_time ) unless $self->{start_time};
+    $self->start_times( $self->get_times ) unless $self->{start_times};
 
     # Make next_state closure
     my $next_state = sub {


### PR DESCRIPTION
Prior to this commit, the timers for counting elapsed time and CPU usage
were begun when a job's first output appears.  For jobs that write only
to stdout, this will typically mean after a block of output is filled.
This can yield inaccurate results.  The worst case is if there is heavy
computation at the beginning of the test being run, before any output is
done.

This commit changes so that the timers are started soon after the job is
created.

As an example of the detrimental effect these inaccurate results could
have is that I found this bug as a result of figuring out why the core
perl test suite was not behaving as expected when changing things around
to increase parallel CPU utilization.  The scheduling algorithm depended
on these results; and since they were wrong, it scheduled things
inefficiently.

This commit, and another to the perl core that takes advantage of this
one, shave 5% to 10% off the time the perl core test suite takes to run.
On slow many-core systems, it is can be 20%.  I also tested this on a
slow single core system, running two parallel jobs.  The savings were 3%
from this commit alone, but that added up to 3 minutes.