### PR TITLE
Fixes for EBCDIC

### DIFF
--- a/lib/TAP/Parser/YAMLish/Writer.pm
+++ b/lib/TAP/Parser/YAMLish/Writer.pm
@@ -10,12 +10,16 @@ our $VERSION = '3.42';
 my $ESCAPE_CHAR = qr{ [ \x00-\x1f \" ] }x;
 my $ESCAPE_KEY  = qr{ (?: ^\W ) | $ESCAPE_CHAR }x;
 
-my @UNPRINTABLE = qw(
-  z    x01  x02  x03  x04  x05  x06  a
-  x08  t    n    v    f    r    x0e  x0f
-  x10  x11  x12  x13  x14  x15  x16  x17
-  x18  x19  x1a  e    x1c  x1d  x1e  x1f
-);
+my @UNPRINTABLE;
+$UNPRINTABLE[$_] = sprintf("x%02x", $_) for 0 .. ord(" ") - 1;
+$UNPRINTABLE[ord "\0"] = 'z';
+$UNPRINTABLE[ord "\a"] = 'a';
+$UNPRINTABLE[ord "\t"] = 't';
+$UNPRINTABLE[ord "\n"] = 'n';
+$UNPRINTABLE[ord "\cK"] = 'v';
+$UNPRINTABLE[ord "\f"] = 'f';
+$UNPRINTABLE[ord "\r"] = 'r';
+$UNPRINTABLE[ord "\e"] = 'e';
 
 # new() implementation supplied by TAP::Object
 


### PR DESCRIPTION
This had hard-coded ordinal numbers for the controls that have a
mnemonic, like \t, and hence failed on EBCDIC platforms where most of
those ordinals are different.

This commit creates a difference between EBCDIC and ASCII platforms.
On EBCDIC it initializes both the C0 and C1 controls; on ASCII, just the
C0.  My guess is that isn't a problem, but this could be easily changed
if needed.

Note that on both platforms there is a control that is an outlier.  It
is \x7f on ASCII, and \xff on EBCDIC.  This isn't initialized in either
case.  I wonder if that is a bug