### PR TITLE
support symlink() being supported, but failing

### DIFF
--- a/t/source.t
+++ b/t/source.t
@@ -242,11 +242,12 @@ SKIP: {
     my $symlink = File::Spec->catfile( $dir, 'source_link.T' );
     my $source  = TAP::Parser::Source->new;
 
-    eval { symlink( File::Spec->rel2abs($test), $symlink ) };
+    my $did_symlink = eval { symlink( File::Spec->rel2abs($test), $symlink ) };
     if ( my $e = $@ ) {
         diag($@);
         die "aborting test";
     }
+    skip "symlink not successful: $!", 9 unless $did_symlink;
 
     $source->raw( \$symlink );
     my $meta = $source->assemble_meta;


### PR DESCRIPTION
This test broke because symlink() (as documented) failed returning
false, which the test ignored.

symlink() (coming soon!) on Win32 requires either elevated
permissions or a sufficiently recent version of Windows 10 with
Developer Mode enabled, which will make this more likely to fail.

This could also happen on POSIX-like systems where the current
filesystem doesn't support symlinks.