### PR TITLE
fix eintr error handling in TAP::Parser::Multiplexer

### DIFF
--- a/lib/TAP/Parser/Multiplexer.pm
+++ b/lib/TAP/Parser/Multiplexer.pm
@@ -4,6 +4,7 @@ use strict;
 use warnings;
 
 use IO::Select;
+use Errno;
 
 use base 'TAP::Object';
 
@@ -130,9 +131,10 @@ sub _iter {
             return ( $parser, $stash, $result );
         }
 
-        unless (@ready) {
+        until (@ready) {
             return unless $sel->count;
             @ready = $sel->can_read;
+            last if @ready || $! != Errno::EINTR;
         }
 
         my ( $h, $parser, $stash, @handles ) = @{ shift @ready };


### PR DESCRIPTION
Fix periodic fails with forkprove running with tests list from STDIN and -j option set to > 1
 
We found out that forkprove (https://metacpan.org/release/forkprove) periodically randomly fails with the following error:
 
```
Can't use an undefined value as an ARRAY reference at /usr/share/perl/5.26/TAP/Parser/Multiplexer.pm line 138, <$reader> line 2.
```
 
We are using it like this:
 
```
forkprove -j 4 - < test_list.txt
```
 
The reason for this is that sometimes select system call is interrupted by `$SIG{CHLD}` handler (I don't know where it is located) and `@ready` array becomes an empty array.
We are introducting a standard technique to handle this case in our PR: to retry select call if error was EINTR (Interrupted system call).