### PR TITLE
Add support for picking up the proverc file from environment

### DIFF
--- a/lib/App/Prove.pm
+++ b/lib/App/Prove.pm
@@ -151,7 +151,21 @@ sub process_args {
     my $self = shift;
 
     my @rc = RC_FILE;
-    unshift @rc, glob '~/' . RC_FILE if IS_UNIXY;
+
+    # look for the RC file in various locations:
+    # $ENV{USERPROFILE} for Windows
+    # ~ for Unix(ish)
+    # $ENV{HOME}
+    # $ENV{XDG_CONFIG_HOME}
+    unshift @rc,  grep { -f $_ }
+                  map  { "$_/" . RC_FILE }
+                  grep { defined && -d }
+                  (
+                   $ENV{XDG_CONFIG_HOME},
+                   $ENV{HOME},
+                   IS_WIN32 ? $ENV{USERPROFILE} : undef,
+                   IS_UNIXY ? '~' : undef,
+                  );
 
     # Preprocess meta-args.
     my @args;


### PR DESCRIPTION
This adds support to find the proverc in other locations that are
usually preferred over the home directory:

$ENV{XDG_CONFIG_HOME}, which is where the "new" place for
user config is under OpenDesktop

$ENV{HOME}, as not every OS/shell sets ~

$ENV{USERPROFILE} for Windows

~ for Unix(ish) OSes

Maybe in a second step it makes sense to optionally pass the
%ENV into ->process_args()