### PR TITLE
Changes to support taint-free perl

### DIFF
--- a/t/regression.t
+++ b/t/regression.t
@@ -20,8 +20,9 @@ use constant NOT_ZERO => "__NOT_ZERO__";
 
 use TAP::Parser;
 
-my $IsVMS   = $^O eq 'VMS';
-my $IsWin32 = $^O eq 'MSWin32';
+my $IsVMS          = $^O eq 'VMS';
+my $IsWin32        = $^O eq 'MSWin32';
+my $NoTaintSupport = exists($Config{taint_support}) && !$Config{taint_support};
 
 my $SAMPLE_TESTS = File::Spec->catdir(
     File::Spec->curdir,
@@ -1361,6 +1362,7 @@ my %samples = (
         parse_errors  => [],
         'exit'        => 0,
         wait          => 0,
+        skip_if       => sub {$NoTaintSupport},
         version       => 12,
     },
     'die' => {


### PR DESCRIPTION
These changes make the test suite pass when this is being
installed under a perl that doesn't support taint.

When you look at the changes, there may well be a cleaner way to support taint-free perl, but these changes meant I could get Perl's tests, and all those for core modules, to pass with both taint-supporting and taint-free perl.

