### PR TITLE
Symlink tests fail in Windows/msys2; skiped

### DIFF
--- a/t/source.t
+++ b/t/source.t
@@ -236,6 +236,7 @@ sub ct($) {
 SKIP: {
     my $symlink_exists = eval { symlink( '', '' ); 1 };
     $symlink_exists = 0 if $^O eq 'VMS'; # exists but not ready for prime time
+    $symlink_exists = 0 if $^O eq 'msys'; # exists but not ready for prime time
     skip 'symlink not supported on this platform', 9 unless $symlink_exists;
 
     my $test    = File::Spec->catfile( $dir, 'source.t' );


### PR DESCRIPTION
Modified source.t to skip tests if $^O is 'msys' to allow module to install in msys2