### PR TITLE
stop using done_testing in harness-bailout

### DIFF
--- a/t/harness-bailout.t
+++ b/t/harness-bailout.t
@@ -195,7 +195,7 @@ package main;
 use strict;
 use warnings;
 
-use Test::More;
+use Test::More tests => 4;
 use TAP::Harness;
 
 sub create_harness {
@@ -235,5 +235,3 @@ is_deeply(
 	[ 'no-bailout', 'bailout', 'no-bailout-parallel', 'bailout-parallel', ],
 	'Jobs finished OK'
 );
-
-done_testing();


### PR DESCRIPTION
Maintains compatibility with older Test::More versions.