### PR TITLE
Skip taint tests when -DSILENT_NO_TAINT_SUPPORT is enabled.

### DIFF
--- a/t/compat/test-harness-compat.t
+++ b/t/compat/test-harness-compat.t
@@ -18,7 +18,9 @@ use Test::Harness qw(execute_tests);
 local $ENV{HARNESS_PERL_SWITCHES};
 
 my $TEST_DIR       = 't/sample-tests';
-my $NoTaintSupport = exists($Config{taint_support}) && !$Config{taint_support};
+my $NoTaintSupport =
+    (exists($Config{taint_support}) && !$Config{taint_support}) ||
+    $Config{ccflags} =~ /-DSILENT_NO_TAINT_SUPPORT/;
 
 my @test_list      = qw(descriptive die die_head_end die_last_minute duplicates
                         head_end head_fail inc_taint junk_before_plan lone_not_bug

--- a/t/regression.t
+++ b/t/regression.t
@@ -22,7 +22,9 @@ use TAP::Parser;
 
 my $IsVMS          = $^O eq 'VMS';
 my $IsWin32        = $^O eq 'MSWin32';
-my $NoTaintSupport = exists($Config{taint_support}) && !$Config{taint_support};
+my $NoTaintSupport =
+    (exists($Config{taint_support}) && !$Config{taint_support}) ||
+    $Config{ccflags} =~ /-DSILENT_NO_TAINT_SUPPORT/;
 
 my $SAMPLE_TESTS = File::Spec->catdir(
     File::Spec->curdir,


### PR DESCRIPTION
If perl is built with -DSILENT_NO_TAINT_SUPPORT checking `$Config{taint_support}` isn't enough, this adds a check that looks for -DSILENT_NO_TAINT_SUPPORT in `$Config{ccflags}`.