### PR TITLE
skip the SEGV test if perl was built with ASAN

### DIFF
--- a/t/harness.t
+++ b/t/harness.t
@@ -535,6 +535,10 @@ for my $test_args ( get_arg_sets() ) {
     SKIP: {
         skip "No SIGSEGV on $^O", 1 if $^O eq 'MSWin32' or $Config::Config{'sig_name'} !~ m/SEGV/;
 
+        # some people -Dcc="somecc -fsanitize=..." or -Doptimize="-fsanitize=..."
+        skip "ASAN doesn't passthrough SEGV", 1
+          if "$Config{cc} $Config{ccflags} $Config{optimize}" =~ /-fsanitize\b/;
+
         @output = ();
         _runtests( $harness_failures, "$sample_tests/segfault" );
 


### PR DESCRIPTION
ASAN reports the fault with a backtrace and does an exit(1) (or _exit(1)) instead of trying to reproduce the SEGV.

Fixes Perl/perl5#19643