### PR TITLE
stop calling import on App::Prove plugins

### DIFF
--- a/lib/App/Prove.pm
+++ b/lib/App/Prove.pm
@@ -412,7 +412,6 @@ sub _load_extension {
     }
 
     if ( my $class = $self->_find_module( $name, @search ) ) {
-        $class->import(@args);
         if ( $class->can('load') ) {
             $class->load( { app_prove => $self, args => [@args] } );
         }
@@ -771,17 +770,6 @@ along with a reference to the C<App::Prove> object that is invoking your plugin:
       $p->{app_prove}->do_something;
       ...
   }
-
-Note that the user's arguments are also passed to your plugin's C<import()>
-function as a list, eg:
-
-  sub import {
-      my ($class, @args) = @_;
-      # @args will contain ( 'foo', 'bar', 'baz' )
-      ...
-  }
-
-This is for backwards compatibility, and may be deprecated in the future.
 
 =head2 Sample Plugin
 

--- a/t/lib/App/Prove/Plugin/Dummy.pm
+++ b/t/lib/App/Prove/Plugin/Dummy.pm
@@ -3,8 +3,8 @@ package App::Prove::Plugin::Dummy;
 use strict;
 use warnings;
 
-sub import {
-    main::test_log_import(@_);
+sub load {
+    main::test_log_plugin_load(@_);
 }
 
 1;

--- a/t/lib/App/Prove/Plugin/Dummy2.pm
+++ b/t/lib/App/Prove/Plugin/Dummy2.pm
@@ -3,10 +3,6 @@ package App::Prove::Plugin::Dummy2;
 use strict;
 use warnings;
 
-sub import {
-    main::test_log_import(@_);
-}
-
 sub load {
     main::test_log_plugin_load(@_);
 }

--- a/t/prove.t
+++ b/t/prove.t
@@ -53,15 +53,6 @@ sub mabs {
 }
 
 {
-    my @import_log = ();
-    sub test_log_import { push @import_log, [@_] }
-
-    sub get_import_log {
-        my @log = @import_log;
-        @import_log = ();
-        return @log;
-    }
-
     my @plugin_load_log = ();
     sub test_log_plugin_load { push @plugin_load_log, [@_] }
 
@@ -1097,8 +1088,8 @@ BEGIN {    # START PLAN
                 plugins => ['Dummy'],
             },
             extra => sub {
-                my @loaded = get_import_log();
-                is_deeply \@loaded, [ ['App::Prove::Plugin::Dummy'] ],
+                my @loaded = get_plugin_load_log();
+                ok @loaded == 1 && $loaded[0][0] eq 'App::Prove::Plugin::Dummy',
                   "Plugin loaded OK";
             },
             plan   => 1,
@@ -1120,13 +1111,12 @@ BEGIN {    # START PLAN
                 plugins => ['Dummy'],
             },
             extra => sub {
-                my @loaded = get_import_log();
-                is_deeply \@loaded,
-                  [ [   'App::Prove::Plugin::Dummy', 'cracking', 'cheese',
-                        'gromit'
-                    ]
-                  ],
+                my @loaded = get_plugin_load_log();
+                ok @loaded == 1 && $loaded[0][0] eq 'App::Prove::Plugin::Dummy',
                   "Plugin loaded OK";
+                my $args = $loaded[0][1]{args};
+                is_deeply $args, [ 'cracking', 'cheese', 'gromit' ],
+                  "Plugin args OK";
             },
             plan   => 1,
             runlog => [
@@ -1147,8 +1137,8 @@ BEGIN {    # START PLAN
                 plugins => ['Dummy'],
             },
             extra => sub {
-                my @loaded = get_import_log();
-                is_deeply \@loaded, [ ['App::Prove::Plugin::Dummy'] ],
+                my @loaded = get_plugin_load_log();
+                ok @loaded == 1 && $loaded[0][0] eq 'App::Prove::Plugin::Dummy',
                   "Plugin loaded OK";
             },
             plan   => 1,
@@ -1170,11 +1160,6 @@ BEGIN {    # START PLAN
                 plugins => ['Dummy2'],
             },
             extra => sub {
-                my @import = get_import_log();
-                is_deeply \@import,
-                  [ [ 'App::Prove::Plugin::Dummy2', 'fou', 'du', 'fafa' ] ],
-                  "Plugin loaded OK";
-
                 my @loaded = get_plugin_load_log();
                 is( scalar @loaded, 1, 'Plugin->load called OK' );
                 my ( $plugin_class, $args ) = @{ shift @loaded };
@@ -1209,8 +1194,8 @@ BEGIN {    # START PLAN
                 plugins => ['Dummy'],
             },
             extra => sub {
-                my @loaded = get_import_log();
-                is_deeply \@loaded, [ ['App::Prove::Plugin::Dummy'] ],
+                my @loaded = get_plugin_load_log();
+                ok @loaded == 1 && $loaded[0][0] eq 'App::Prove::Plugin::Dummy',
                   "Plugin loaded OK";
             },
             plan   => 1,


### PR DESCRIPTION
App::Prove plugins are passed their arguments via the load method, but for backwards compatibility also passed the arguments with an import call. This relies on perl ignoring the import call if the plugin does not have such a method.

Future versions of perl are intending to throw errors for unhandled import arguments like this. None of the plugins on CPAN include import methods, so the easiest fix for this seems to be removing the import call.