### PR TITLE
Use shared workflow 'simple-perltester-workflow'

### DIFF
--- a/.github/workflows/smoke-perltester-workflow.yml
+++ b/.github/workflows/smoke-perltester-workflow.yml
@@ -1,0 +1,30 @@
+name: smoke-ubuntu-linux
+
+on:
+  push:
+    branches:
+      - "*"
+    tags-ignore:
+      - "*"
+  pull_request:
+
+  # allow to trigger workflow manually
+  workflow_dispatch:
+
+  # once a month check if still runs (newer dependencies - perl, libraries, actions, ...)
+  schedule:
+    - cron: 0 0 1 * *
+
+env:
+  PERL_USE_UNSAFE_INC: 0
+  AUTHOR_TESTING: 1
+  AUTOMATED_TESTING: 1
+  RELEASE_TESTING: 1
+  PERL_DL_NONLAZY: 1
+
+jobs:
+  simple-perltester-workflow:
+    uses: perl-actions/github-workflows/.github/workflows/simple-perltester-workflow.yml@main
+    with:
+      since-perl: 5.8
+


### PR DESCRIPTION
reusable workflow generates tests since "since-perl" up to newest (generating matrix adapting to new release of perl without any change in repo), using perltester docker images

therefor also cron schedule