### PR TITLE
bail out test will generate 2 summaries

### DIFF
--- a/lib/TAP/Harness.pm
+++ b/lib/TAP/Harness.pm
@@ -558,8 +558,8 @@ sub runtests {
         my $bailout;
         eval { $self->aggregate_tests( $aggregate, @tests ); 1 }
             or do { $bailout = $@ || 'unknown_error' };
-        $finish->();
         die $bailout if defined $bailout;
+        $finish->();
     };
     $self->{bail_summary} = sub{
         print "\n";


### PR DESCRIPTION
example:
```
use strict;
use warnings;
use Test::More tests=>2;
ok(1, "first test");
BAIL_OUT("bailing out");
ok(2, "second test");
```
output:
```
bailout.t .. 1/2 Bailout called.  Further testing stopped:  bailing out
bailout.t .. Dubious, test returned 255 (wstat 65280, 0xff00)
Failed 1/2 subtests

Test run interrupted!

Test Summary Report
-------------------
bailout.t (Wstat: 65280 (exited 255) Tests: 1 Failed: 0)
  Non-zero exit status: 255
  Parse errors: Bad plan.  You planned 2 tests but ran 1.
Files=1, Tests=1,  0 wallclock secs ( 0.00 usr  0.00 sys +  0.02 cusr  0.00 csys =  0.02 CPU)
Result: FAIL

Test Summary Report
-------------------
bailout.t (Wstat: 65280 (exited 255) Tests: 1 Failed: 0)
  Non-zero exit status: 255
  Parse errors: Bad plan.  You planned 2 tests but ran 1.
Files=1, Tests=1,  0 wallclock secs ( 0.00 usr  0.00 sys +  0.02 cusr  0.00 csys =  0.02 CPU)
Result: FAIL
FAILED--Further testing stopped: bailing out

```