### PR TITLE
fix string comparisons with $] to use numeric comparison instead

### DIFF
--- a/lib/TAP/Harness.pm
+++ b/lib/TAP/Harness.pm
@@ -494,7 +494,7 @@ Any keys for which the value is C<undef> will be ignored.
                warn "CPAN::Meta::YAML required to process $rulesfile" ;
                return;
             }
-            my $layer = $] lt "5.008" ? "" : ":encoding(UTF-8)";
+            my $layer = "$]" < "5.008" ? "" : ":encoding(UTF-8)";
             open my $fh, "<$layer", $rulesfile
                 or die "Couldn't open $rulesfile: $!";
             my $yaml_text = do { local $/; <$fh> };


### PR DESCRIPTION
The fix follows Zefram's suggestion from
https://www.nntp.perl.org/group/perl.perl5.porters/2012/05/msg186846.html

> On older perls, however, $] had a numeric value that was built up using
> floating-point arithmetic, such as 5+0.006+0.000002.  This would not
> necessarily match the conversion of the complete value from string form
> [perl #72210].  You can work around that by explicitly stringifying
> $] (which produces a correct string) and having *that* numify (to a
> correctly-converted floating point value) for comparison.  I cultivate
> the habit of always stringifying $] to work around this, regardless of
> the threshold where the bug was fixed.  So I'd write
>
>     use if "$]" >= 5.014, warnings => "non_unicode";