### PR TITLE
Extract runtime detection constants into separated module

### DIFF
--- a/lib/App/Prove.pm
+++ b/lib/App/Prove.pm
@@ -4,6 +4,7 @@ use strict;
 use warnings;
 
 use TAP::Harness::Env;
+use TAP::Harness::Runtime qw (IS_UNIXY IS_VMS IS_WIN32);
 use Text::ParseWords qw(shellwords);
 use File::Spec;
 use Getopt::Long;
@@ -39,10 +40,6 @@ wrapper around an instance of this module.
     $app->run;
 
 =cut
-
-use constant IS_WIN32 => ( $^O =~ /^(MS)?Win32$/ );
-use constant IS_VMS => $^O eq 'VMS';
-use constant IS_UNIXY => !( IS_VMS || IS_WIN32 );
 
 use constant STATE_FILE => IS_UNIXY ? '.prove'   : '_prove';
 use constant RC_FILE    => IS_UNIXY ? '.proverc' : '_proverc';

--- a/lib/App/Prove/State.pm
+++ b/lib/App/Prove/State.pm
@@ -10,13 +10,14 @@ use Carp;
 use App::Prove::State::Result;
 use TAP::Parser::YAMLish::Reader ();
 use TAP::Parser::YAMLish::Writer ();
+use TAP::Harness::Runtime qw (IS_WIN32);
+
 use base 'TAP::Base';
 
 BEGIN {
     __PACKAGE__->mk_methods('result_class');
 }
 
-use constant IS_WIN32 => ( $^O =~ /^(MS)?Win32$/ );
 use constant NEED_GLOB => IS_WIN32;
 
 =head1 NAME

--- a/lib/TAP/Base.pm
+++ b/lib/TAP/Base.pm
@@ -5,6 +5,8 @@ use warnings;
 
 use base 'TAP::Object';
 
+use TAP::Harness::Runtime qw (time HAS_TIME_HIRES);
+
 =head1 NAME
 
 TAP::Base - Base class that provides common functionality to L<TAP::Parser>
@@ -18,10 +20,7 @@ Version 3.51_01
 
 our $VERSION = '3.51_01';
 
-use constant GOT_TIME_HIRES => do {
-    eval 'use Time::HiRes qw(time);';
-    $@ ? 0 : 1;
-};
+use constant GOT_TIME_HIRES => HAS_TIME_HIRES;
 
 =head1 SYNOPSIS
 

--- a/lib/TAP/Formatter/Color.pm
+++ b/lib/TAP/Formatter/Color.pm
@@ -3,7 +3,7 @@ package TAP::Formatter::Color;
 use strict;
 use warnings;
 
-use constant IS_WIN32 => ( $^O =~ /^(MS)?Win32$/ );
+use TAP::Harness::Runtime qw (IS_WIN32);
 
 use base 'TAP::Object';
 

--- a/lib/TAP/Harness/Env.pm
+++ b/lib/TAP/Harness/Env.pm
@@ -3,7 +3,8 @@ package TAP::Harness::Env;
 use strict;
 use warnings;
 
-use constant IS_VMS => ( $^O eq 'VMS' );
+use TAP::Harness::Runtime qw (IS_VMS);
+
 use TAP::Object;
 use Text::ParseWords qw/shellwords/;
 

--- a/lib/TAP/Harness/Runtime.pm
+++ b/lib/TAP/Harness/Runtime.pm
@@ -5,7 +5,14 @@ use warnings;
 
 use base q (Exporter);
 
-use constant HAS_TIME_HIRES => !! eval q { use Time::HiRes qw (time); 1 };
+use Time::HiRes;
+
+use constant HAS_TIME_HIRES => !! eval {
+	require Time::HiRes;
+	Time::HiRes->import (qw (time));
+	1
+};
+
 use constant IS_VMS         => $^O eq q (VMS);
 use constant IS_WIN32       => ($^O =~ qr (^ (MS) Win32 $)x);
 use constant IS_UNIXY       => ! (IS_VMS || IS_WIN32);

--- a/lib/TAP/Harness/Runtime.pm
+++ b/lib/TAP/Harness/Runtime.pm
@@ -1,0 +1,118 @@
+package TAP::Harness::Runtime;
+
+use strict;
+use warnings;
+
+use base q (Exporter);
+
+use constant HAS_TIME_HIRES => !! eval { use Time::HiRes qw (time); 1 };
+use constant IS_VMS         => $^O eq q (VMS);
+use constant IS_WIN32       => ($^O =~ qr (^ (MS) Win32 $)x);
+use constant IS_UNIXY       => ! (IS_VMS || IS_WIN32);
+
+my @constants = qw (
+	IS_VMS
+	IS_WIN32
+	IS_UNIXY
+	HAS_TIME_HIRES
+);
+
+our @EXPORT_OK = (
+	@constants,
+	HAS_TIME_HIRES ? qw (time) : (),
+);
+
+our %EXPORT_TAGS = (
+	all       => \ @EXPORT_OK,
+	constants => \ @constants,
+);
+
+sub import {
+	my ($caller, @arguments) = @_;
+
+	# 'time' is exported only when Time::HiRes is available
+	# but can be always requested
+	@arguments = grep { $_ ne q (time) } @arguments
+		unless HAS_TIME_HIRES
+		;
+
+	local @_ = ($caller, @arguments);
+	goto \ &Exporter::import;
+}
+
+1;
+
+__END__
+
+=pod
+
+=encoding utf8
+
+=head1 NAME
+
+TAP::Harness::Runtime - constants to identify runtime environment
+
+=head1 SYNOPSIS
+
+    package My:Superb::Package;
+
+    # import constants
+    use TAP::Harness::Runtime qw (:constants);
+
+=head1 DESCRIPTION
+
+Module wraps runtime detection used by multiple modules into single module.
+
+=head1 EXPORTABLE FUNCTIONS
+
+=head2 HAS_TIME_HIRES
+
+Constant evaluating as C<true> when module L<Time::HiRes> is importable.
+
+=head2 IS_VMS
+
+Constant evaluating as C<true> when running on VMS.
+
+=head2 IS_WIN32
+
+Constant evaluating as C<true> when running on Windows (32-bit or 64-bit)
+
+=head2 IS_UNIXY
+
+Constant evaluating as C<true> when running system which behaves like Unix.
+
+=head2 time
+
+When L<Time::HiRes> is available module reexports its C<time> function.
+
+Symbol can be requested for import even if L<Time::HiRes> isn't available
+without causing any error.
+
+=head1 EXPORT TAGS
+
+=head2 all
+
+Import all exported symbols.
+
+=head2 constants
+
+Import all constants.
+
+=head1 SEE ALSO
+
+L<TAP::Harness>
+
+=head1 BUGS
+
+Please report any bugs or feature request at
+L<https://github.com/Perl-Toolchain-Gang/Test-Harness/issues>
+
+=head1 REPOSITORY
+
+L<https://github.com/Perl-Toolchain-Gang/Test-Harness>
+
+=head1 LICENCE AND COPYRIGHT
+
+This module is free software; you can redistribute it and/or
+modify it under same terms as L<Test::Harness> distribution.
+

--- a/lib/TAP/Harness/Runtime.pm
+++ b/lib/TAP/Harness/Runtime.pm
@@ -5,7 +5,7 @@ use warnings;
 
 use base q (Exporter);
 
-use constant HAS_TIME_HIRES => !! eval { use Time::HiRes qw (time); 1 };
+use constant HAS_TIME_HIRES => !! eval q { use Time::HiRes qw (time); 1 };
 use constant IS_VMS         => $^O eq q (VMS);
 use constant IS_WIN32       => ($^O =~ qr (^ (MS) Win32 $)x);
 use constant IS_UNIXY       => ! (IS_VMS || IS_WIN32);

--- a/lib/TAP/Parser/Iterator.pm
+++ b/lib/TAP/Parser/Iterator.pm
@@ -5,6 +5,8 @@ use warnings;
 
 use base 'TAP::Object';
 
+use TAP::Harness::Runtime qw (IS_VMS);
+
 =head1 NAME
 
 TAP::Parser::Iterator - Base class for TAP source iterators
@@ -61,7 +63,7 @@ Iterate raw input without applying any fixes for quirky input syntax.
 
 =cut
 
-if ( $^O eq 'VMS' ) {
+if (IS_VMS) {
     eval <<'END' ;
 sub next {
     my $self = shift;

--- a/lib/TAP/Parser/Iterator/Process.pm
+++ b/lib/TAP/Parser/Iterator/Process.pm
@@ -8,7 +8,7 @@ use IO::Handle;
 
 use base 'TAP::Parser::Iterator';
 
-use constant IS_WIN32 => !!( $^O =~ /^(MS)?Win32$/ );
+use TAP::Harness::Runtime qw (IS_WIN32);
 
 =head1 NAME
 

--- a/lib/TAP/Parser/Multiplexer.pm
+++ b/lib/TAP/Parser/Multiplexer.pm
@@ -8,9 +8,9 @@ use Errno;
 
 use base 'TAP::Object';
 
-use constant IS_WIN32 => $^O =~ /^(MS)?Win32$/;
-use constant IS_VMS => $^O eq 'VMS';
-use constant SELECT_OK => !( IS_VMS || IS_WIN32 );
+use TAP::Harness::Runtime qw (IS_UNIXY IS_VMS IS_WIN32);
+
+use constant SELECT_OK => IS_UNIXY;
 
 =head1 NAME
 

--- a/lib/TAP/Parser/SourceHandler/Perl.pm
+++ b/lib/TAP/Parser/SourceHandler/Perl.pm
@@ -4,8 +4,7 @@ use strict;
 use warnings;
 use Config;
 
-use constant IS_WIN32 => ( $^O =~ /^(MS)?Win32$/ );
-use constant IS_VMS => ( $^O eq 'VMS' );
+use TAP::Harness::Runtime qw (IS_VMS IS_WIN32);
 
 use TAP::Parser::IteratorFactory           ();
 use TAP::Parser::Iterator::Process         ();

--- a/lib/Test/Harness.pm
+++ b/lib/Test/Harness.pm
@@ -5,10 +5,8 @@ use 5.006;
 use strict;
 use warnings;
 
-use constant IS_WIN32 => ( $^O =~ /^(MS)?Win32$/ );
-use constant IS_VMS => ( $^O eq 'VMS' );
-
 use TAP::Harness                     ();
+use TAP::Harness::Runtime            qw (HAS_TIME_HIRES IS_WIN32 IS_VMS);
 use TAP::Parser::Aggregator          ();
 use TAP::Parser::Source              ();
 use TAP::Parser::SourceHandler::Perl ();
@@ -20,10 +18,7 @@ use base 'Exporter';
 
 # $ML $Last_ML_Print
 
-BEGIN {
-    eval q{use Time::HiRes 'time'};
-    our $has_time_hires = !$@;
-}
+our $has_time_hires = HAS_TIME_HIRES;
 
 =head1 NAME
 

--- a/t/compat/env.t
+++ b/t/compat/env.t
@@ -6,8 +6,9 @@ use strict;
 use warnings;
 use lib 't/lib';
 
+use TAP::Harness::Runtime qw (IS_VMS);
 use Test::More (
-    $^O eq 'VMS'
+    IS_VMS
     ? ( skip_all => 'VMS' )
     : ( tests => 1 )
 );

--- a/t/compat/inc-propagation.t
+++ b/t/compat/inc-propagation.t
@@ -8,6 +8,8 @@ use warnings;
 use lib 't/lib';
 use Config;
 
+use TAP::Harness::Runtime qw (IS_VMS);
+
 local
   $ENV{PERL5OPT};   # avoid any user-provided PERL5OPT from contaminating @INC
 
@@ -22,7 +24,7 @@ sub has_crazy_patch {
 }
 
 use Test::More (
-      $^O eq 'VMS' ? ( skip_all => 'VMS' )
+      IS_VMS ? ( skip_all => 'VMS' )
     : has_crazy_patch() ? ( skip_all => 'Incompatible @INC patch' )
     : exists $ENV{HARNESS_PERL_SWITCHES}
     ? ( skip_all => 'Someone messed with HARNESS_PERL_SWITCHES' )

--- a/t/compat/subclass.t
+++ b/t/compat/subclass.t
@@ -6,8 +6,9 @@ use strict;
 use warnings;
 use lib 't/lib';
 
+use TAP::Harness::Runtime qw (IS_VMS);
 use Test::More (
-    $^O eq 'VMS'
+    IS_VMS
     ? ( skip_all => 'VMS' )
     : ( tests => 1 )
 );

--- a/t/compat/switches.t
+++ b/t/compat/switches.t
@@ -2,8 +2,10 @@
 
 use strict;
 use warnings;
+
+use TAP::Harness::Runtime qw (IS_VMS);
 use Test::More (
-    $^O eq 'VMS'
+    IS_VMS
     ? ( skip_all => 'VMS' )
     : ( tests => 4 )
 );

--- a/t/compat/test-harness-compat.t
+++ b/t/compat/test-harness-compat.t
@@ -10,6 +10,8 @@ use Config;
 
 # use lib 't/lib';
 
+use TAP::Harness::Runtime qw (IS_VMS);
+
 use Test::More;
 use File::Spec;
 use Test::Harness qw(execute_tests);
@@ -150,7 +152,7 @@ if ($NoTaintSupport) {
                     'name'   => "$TEST_DIR/too_many",
                     'wstat'  => '1024'
                 },
-                ( $^O eq 'VMS' ?
+                ( IS_VMS ?
                     ("$TEST_DIR/vms_nit" => {
                        'canon'  => 1,
                        'estat'  => '',
@@ -173,12 +175,12 @@ if ($NoTaintSupport) {
                 }
             },
             'totals' => {
-                'bad'         => ($NoTaintSupport ? 11 : 12)-($^O eq 'VMS' ? 0 : 1),
+                'bad'         => ($NoTaintSupport ? 11 : 12)-(IS_VMS ? 0 : 1),
                 'bonus'       => 1,
                 'files'       => ($NoTaintSupport ? 24 : 27),
-                'good'        => ($NoTaintSupport ? 13 : 15)+($^O eq 'VMS' ? 0 : 1),
+                'good'        => ($NoTaintSupport ? 13 : 15)+(IS_VMS ? 0 : 1),
                 'max'         => ($NoTaintSupport ? 72 : 76),
-                'ok'          => ($NoTaintSupport ? 75 : 78)+($^O eq 'VMS' ? 0 : 1),
+                'ok'          => ($NoTaintSupport ? 75 : 78)+(IS_VMS ? 0 : 1),
                 'skipped'     => 2,
                 'sub_skipped' => 2,
                 'tests'       => ($NoTaintSupport ? 24 : 27),
@@ -742,7 +744,7 @@ if ($NoTaintSupport) {
                 'todo'        => 0
             }
         },
-        ( $^O eq 'VMS' ?
+        ( IS_VMS ?
             ('vms_nit' => {
                 'failed' => {
                     "$TEST_DIR/vms_nit" => {
@@ -797,7 +799,7 @@ if ($NoTaintSupport) {
 
     sub vague_status {
         my $hash = shift;
-        return $hash unless $^O eq 'VMS';
+        return $hash unless IS_VMS;
 
         while ( my ( $file, $want ) = each %$hash ) {
             for (qw( estat wstat )) {

--- a/t/perl5lib.t
+++ b/t/perl5lib.t
@@ -8,6 +8,8 @@ use warnings;
 use lib 't/lib';
 use Config;
 
+use TAP::Harness::Runtime qw (IS_VMS);
+
 my $path_sep = $Config{path_sep};
 
 sub has_crazy_patch {
@@ -21,7 +23,7 @@ sub has_crazy_patch {
 }
 
 use Test::More (
-      $^O eq 'VMS' ? ( skip_all => 'VMS' )
+      IS_VMS ? ( skip_all => 'VMS' )
     : has_crazy_patch() ? ( skip_all => 'Incompatible @INC patch' )
     : ( tests => 1 )
 );

--- a/t/process.t
+++ b/t/process.t
@@ -10,8 +10,9 @@ BEGIN {
     $hires = eval 'use Time::HiRes qw(sleep); 1';
 }
 
+use TAP::Harness::Runtime qw (IS_VMS);
 use Test::More (
-      $^O eq 'VMS' ? ( skip_all => 'VMS' )
+      IS_VMS ? ( skip_all => 'VMS' )
     : $hires ? ( tests => 9 * 3 )
     : ( skip_all => 'Need Time::HiRes' )
 );

--- a/t/regression.t
+++ b/t/regression.t
@@ -7,6 +7,8 @@ BEGIN {
 use strict;
 use warnings;
 
+use TAP::Harness::Runtime qw (IS_VMS IS_WIN32);
+
 use Test::More 'no_plan';
 
 use File::Spec;
@@ -20,8 +22,8 @@ use constant NOT_ZERO => "__NOT_ZERO__";
 
 use TAP::Parser;
 
-my $IsVMS          = $^O eq 'VMS';
-my $IsWin32        = $^O eq 'MSWin32';
+my $IsVMS          = IS_VMS;
+my $IsWin32        = IS_WIN32;
 my $NoTaintSupport = exists($Config{taint_support}) && !$Config{taint_support};
 
 my $SAMPLE_TESTS = File::Spec->catdir(

--- a/t/source.t
+++ b/t/source.t
@@ -7,6 +7,7 @@ BEGIN {
 use strict;
 use warnings;
 
+use TAP::Harness::Runtime qw (IS_VMS);
 use Test::More tests => 45;
 use File::Spec;
 
@@ -235,7 +236,7 @@ sub ct($) {
 # symlink test
 SKIP: {
     my $symlink_exists = eval { symlink( '', '' ); 1 };
-    $symlink_exists = 0 if $^O eq 'VMS'; # exists but not ready for prime time
+    $symlink_exists = 0 if IS_VMS; # exists but not ready for prime time
     $symlink_exists = 0 if $^O eq 'msys'; # exists but not ready for prime time
     skip 'symlink not supported on this platform', 9 unless $symlink_exists;
 

--- a/t/source_handler.t
+++ b/t/source_handler.t
@@ -16,8 +16,9 @@ use File::Spec;
 
 use TAP::Parser::Source;
 use TAP::Parser::SourceHandler;
+use TAP::Harness::Runtime qw (IS_WIN32);
 
-my $IS_WIN32 = ( $^O =~ /^(MS)?Win32$/ );
+my $IS_WIN32 = IS_WIN32;
 my $HAS_SH   = -x '/bin/sh';
 my $HAS_ECHO = -x '/bin/echo';
 

--- a/t/taint.t
+++ b/t/taint.t
@@ -8,7 +8,9 @@ BEGIN {
 
 use strict;
 use warnings;
-use Test::More ( $^O eq 'VMS' ? ( skip_all => 'VMS' ) : ( tests => 2 ) );
+
+use TAP::Harness::Runtime qw (IS_VMS);
+use Test::More ( IS_VMS ? ( skip_all => 'VMS' ) : ( tests => 2 ) );
 
 use Config;
 use TAP::Parser;


### PR DESCRIPTION
Runtime detection code was implemented in multiple sources many times using same logic.

Extracting such logic into module and import required behaviour as symbols improves reliability of source code (using symbols instead of constants, write logic only once) as well as (usually) shows some improvements possibilities.
