### PR TITLE
Fix problem with defining rules

### DIFF
--- a/lib/App/Prove.pm
+++ b/lib/App/Prove.pm
@@ -372,13 +372,13 @@ sub _get_args {
         my @rules;
         for ( @{ $self->rules } ) {
             if (/^par=(.*)/) {
-                push @rules, $1;
+                push @rules, { par => $1 };
             }
             elsif (/^seq=(.*)/) {
                 push @rules, { seq => $1 };
             }
         }
-        $args{rules} = { par => [@rules] };
+        $args{rules} = { seq => [@rules] };
     }
     $args{harness_class} = $self->{harness_class} if $self->{harness_class};
 


### PR DESCRIPTION
Fixes: #75

I suppose problem is here:
https://github.com/Perl-Toolchain-Gang/Test-Harness/blob/master/lib/App/Prove.pm#L371-L383

This code returns:
```
  rules => {
    par => [
      {
        seq => xx/start.t,
      },
      xx/t*,
      {
        seq => xx/finish.t,
      },
    ],
  },
```

For `prove --jobs=5 xx/*.t --rules='seq=xx/start.t' --rules='par=xx/t*' --rules='seq=xx/finish.t` command.

Though I am ok that tests are run in parallel by default. This line of code `$args{rules} = { par => [@rules] };` breaks this state in documentation:

> The option may be specified multiple times, and the order matters.

https://metacpan.org/dist/Test-Harness/view/bin/prove#-rules

### Solution
With this fix I am able to achieve this behavior: https://perldoc.perl.org/TAP::Parser::Scheduler#Rules-examples

```
# Run some  startup tests in sequence, then some parallel tests then some
# teardown tests in sequence.
{
    seq => [
        { seq => 't/startup/*.t' },
        { par => ['t/a/*.t','t/b/*.t','t/c/*.t'], }
        { seq => 't/shutdown/*.t' },
    ],
},
```

For `prove --jobs=5 xx/*.t --rules='seq=xx/start.t' --rules='par=xx/t*' --rules='seq=xx/finish.t` command when options are read the structure look correct:

```
DBG> $args{rules}
{
  seq => [
    {
      seq => xx/start.t,
    },
    {
      par => xx/t*,
    },
    {
      seq => xx/finish.t,
    },
  ],
}
```

And the test `t/start.t` run before everything, `xx/t*` in parallel after it. When finished the `t/finish.t` is run.