### PR TITLE
Make Time::HiRes a mandatory dependency

### DIFF
--- a/lib/App/Prove/State/Result/Test.pm
+++ b/lib/App/Prove/State/Result/Test.pm
@@ -113,8 +113,7 @@ TODO passed).
 
 =head3 C<run_time>
 
-The total time it took for the test to run, in seconds.  If C<Time::HiRes> is
-available, it will have finer granularity.
+The total time it took for the test to run, in seconds.
 
 =head3 C<num_todo>
 

--- a/lib/TAP/Base.pm
+++ b/lib/TAP/Base.pm
@@ -18,10 +18,7 @@ Version 3.51_01
 
 our $VERSION = '3.51_01';
 
-use constant GOT_TIME_HIRES => do {
-    eval 'use Time::HiRes qw(time);';
-    $@ ? 0 : 1;
-};
+use Time::HiRes qw(time);
 
 =head1 SYNOPSIS
 
@@ -107,19 +104,14 @@ sub _make_callback {
 
 =head3 C<get_time>
 
-Return the current time using Time::HiRes if available.
+Return the current time.
 
 =cut
 
 sub get_time { return time() }
 
-=head3 C<time_is_hires>
-
-Return true if the time returned by get_time is high resolution (i.e. if Time::HiRes is available).
-
-=cut
-
-sub time_is_hires { return GOT_TIME_HIRES }
+# kept for backwards compatability
+sub time_is_hires { return 1 }
 
 =head3 C<get_times>
 

--- a/lib/TAP/Formatter/Base.pm
+++ b/lib/TAP/Formatter/Base.pm
@@ -141,7 +141,7 @@ Printing individual test results to STDOUT.
 
 =item * C<timer>
 
-Append run time for each test to output. Uses L<Time::HiRes> if available.
+Append run time for each test to output.
 
 =item * C<failures>
 

--- a/lib/TAP/Harness.pm
+++ b/lib/TAP/Harness.pm
@@ -156,8 +156,7 @@ Set the verbosity level:
 
 =item * C<timer>
 
-Append run time for each test to output. Uses L<Time::HiRes> if
-available.
+Append run time for each test to output.
 
 =item * C<failures>
 

--- a/lib/Test/Harness.pm
+++ b/lib/Test/Harness.pm
@@ -14,16 +14,14 @@ use TAP::Parser::Source              ();
 use TAP::Parser::SourceHandler::Perl ();
 
 use Text::ParseWords qw(shellwords);
+use Time::HiRes 'time';
 
 use Config;
 use base 'Exporter';
 
 # $ML $Last_ML_Print
 
-BEGIN {
-    eval q{use Time::HiRes 'time'};
-    our $has_time_hires = !$@;
-}
+our $has_time_hires = 1;
 
 =head1 NAME
 


### PR DESCRIPTION
Time::HiRes has been in core since 5.8.0 (2002). I think at this point we can assume it's there.

This would mean TAP::Harness can no longer run under miniperl, but minitest wasn't using it in the first place so I think we're OK.